### PR TITLE
core: Improve IO speed on non-Linux operating systems

### DIFF
--- a/xdvdfs-core/src/layout.rs
+++ b/xdvdfs-core/src/layout.rs
@@ -264,6 +264,18 @@ impl DirectoryEntryDiskData {
 
         Ok(buf)
     }
+
+    #[cfg(all(feature = "read", feature = "std"))]
+    pub fn seek_to(
+        &self,
+        seek: &mut impl std::io::Seek,
+    ) -> Result<(), util::Error<std::io::Error>> {
+        use std::io::SeekFrom;
+
+        let offset = self.data.offset(0)?;
+        seek.seek(SeekFrom::Start(offset))?;
+        Ok(())
+    }
 }
 
 impl DirectoryEntryNode {

--- a/xdvdfs-core/src/write/dirtab.rs
+++ b/xdvdfs-core/src/write/dirtab.rs
@@ -219,6 +219,11 @@ impl DirectoryEntryTableWriter {
             assert_eq!(Some(dirent_bytes.len() as u64), self.size);
         }
 
+        let size = dirent_bytes.len();
+        assert!(size > 0);
+        let padding_len = (2048 - size % 2048) % 2048;
+        dirent_bytes.extend(alloc::vec![0xff; padding_len]);
+
         Ok(DirectoryEntryTableDiskRepr {
             entry_table: dirent_bytes.into_boxed_slice(),
             file_listing,


### PR DESCRIPTION
This doesn't go all the way to fixing the IO speed issues, but seems to have some effect. This also changes unpack to use `std::io::copy` to benefit from specialization on Linux