### PR TITLE
Add CISO support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -p xdvdfs-cli --release --features=sync
+          args: -p xdvdfs-cli --release
 
       - name: Package artifact
         run: zip -j xdvdfs-linux-${{ github.sha }}.zip LICENSE target/release/xdvdfs
@@ -115,7 +115,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -p xdvdfs-cli --release --target=x86_64-pc-windows-gnu --features=sync
+          args: -p xdvdfs-cli --release --target=x86_64-pc-windows-gnu
           use-cross: true
 
       - name: Package artifact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,11 @@ members = [
     "xdvdfs-web",
 ]
 
+resolver = "2"
+
 [workspace.package]
 license = "MIT"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 repository = "https://github.com/antangelo/xdvdfs"
 homepage = "https://github.com/antangelo/xdvdfs"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Commands:
   info      Print information about image metadata
   unpack    Unpack an entire image to a directory
   pack      Pack an image from a given directory or source ISO image
+  compress  Pack and compress an image from a given directory or source ISO image
   help      Print this message or the help of the given subcommand(s)
 ```
 

--- a/xdvdfs-cli/Cargo.toml
+++ b/xdvdfs-cli/Cargo.toml
@@ -13,16 +13,18 @@ homepage.workspace = true
 exclude = ["**/*.iso", "**/*.xiso"]
 
 [dependencies]
-xdvdfs = { path = "../xdvdfs-core", version = "0.5.2" }
+xdvdfs = { path = "../xdvdfs-core", version = "0.6.0" }
 clap = { version = "4.2.1", features = ["derive"] }
 md-5 = { version = "0.10.5", default-features = false }
 futures = "0.3.28"
 anyhow = "1.0.71"
 env_logger = "0.10.0"
 maybe-async = "0.2.7"
+ciso = { version = "0.1.0", default-features = false }
+async-trait = "0.1.73"
 
 [features]
-sync = ["xdvdfs/sync"]
+sync = ["xdvdfs/sync", "maybe-async/is_sync"]
 
 [[bin]]
 name = "xdvdfs"

--- a/xdvdfs-cli/README.md
+++ b/xdvdfs-cli/README.md
@@ -25,6 +25,7 @@ Commands:
   info      Print information about image metadata
   unpack    Unpack an entire image to a directory
   pack      Pack an image from a given directory or source ISO image
+  compress  Pack and compress an image from a given directory or source ISO image
   help      Print this message or the help of the given subcommand(s)
 ```
 

--- a/xdvdfs-cli/src/cmd_compress.rs
+++ b/xdvdfs-cli/src/cmd_compress.rs
@@ -1,0 +1,123 @@
+use std::path::{Path, PathBuf};
+
+use maybe_async::maybe_async;
+
+use xdvdfs::{
+    blockdev,
+    write::{self, img::ProgressInfo},
+};
+
+use crate::img::open_image_raw;
+
+struct SplitStdFs;
+
+type BufFile = std::io::BufWriter<std::fs::File>;
+type BufFileSectorLinearFs<'a> = write::fs::SectorLinearBlockFilesystem<
+    'a,
+    std::io::Error,
+    std::fs::File,
+    write::fs::XDVDFSFilesystem<
+        std::io::Error,
+        blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>, std::io::Error>,
+    >,
+>;
+
+#[maybe_async(?Send)]
+impl ciso::split::SplitFilesystem<std::io::Error, BufFile> for SplitStdFs {
+    async fn create_file(&mut self, name: &std::ffi::OsStr) -> Result<BufFile, std::io::Error> {
+        let file = std::fs::File::create(name)?;
+        let bf: BufFile = std::io::BufWriter::new(file);
+        Ok(bf)
+    }
+
+    async fn close(&mut self, _: BufFile) {}
+}
+
+fn get_default_image_path(source_path: &Path) -> Option<PathBuf> {
+    let source_file_name = source_path.file_name()?;
+    let output = PathBuf::from(source_file_name).with_extension("cso");
+
+    Some(output)
+}
+
+#[maybe_async(?Send)]
+pub async fn cmd_compress(
+    source_path: &String,
+    image_path: &Option<String>,
+) -> Result<(), anyhow::Error> {
+    let source_path = PathBuf::from(source_path);
+
+    let image_path = image_path
+        .as_ref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| get_default_image_path(&source_path).unwrap());
+
+    let mut output = ciso::split::SplitOutput::new(SplitStdFs, image_path);
+
+    let progress_callback = |pi| match pi {
+        ProgressInfo::DirAdded(path, sector) => {
+            println!("Added dir: {:?} at sector {}", path, sector);
+        }
+        ProgressInfo::FileAdded(path, sector) => {
+            println!("Added file: {:?} at sector {}", path, sector);
+        }
+        _ => {}
+    };
+
+    let mut total_sectors = 0;
+    let mut sectors_finished = 0;
+    let progress_callback_compression = |pi| match pi {
+        ciso::write::ProgressInfo::SectorCount(c) => total_sectors = c,
+        ciso::write::ProgressInfo::SectorFinished => {
+            sectors_finished += 1;
+            print!(
+                "\rCompressing sectors ({}/{})",
+                sectors_finished, total_sectors
+            );
+        }
+        ciso::write::ProgressInfo::Finished => println!(),
+        _ => {}
+    };
+
+    let meta = std::fs::metadata(&source_path)?;
+    if meta.is_dir() {
+        let mut fs = write::fs::StdFilesystem;
+        let mut slbd = write::fs::SectorLinearBlockDevice::default();
+        let mut slbfs: write::fs::SectorLinearBlockFilesystem<
+            std::io::Error,
+            std::fs::File,
+            write::fs::StdFilesystem,
+        > = write::fs::SectorLinearBlockFilesystem::new(&mut fs);
+
+        write::img::create_xdvdfs_image(&source_path, &mut slbfs, &mut slbd, progress_callback)
+            .await?;
+
+        let mut input = write::fs::CisoSectorInput::new(slbd, slbfs);
+        ciso::write::write_ciso_image(&mut input, &mut output, progress_callback_compression)
+            .await?;
+    } else if meta.is_file() {
+        let source = open_image_raw(&source_path).await?;
+        let mut fs = write::fs::XDVDFSFilesystem::new(source)
+            .await
+            .ok_or(anyhow::anyhow!("Failed to create XDVDFS filesystem"))?;
+        let mut slbd = write::fs::SectorLinearBlockDevice::default();
+        let mut slbfs: BufFileSectorLinearFs = write::fs::SectorLinearBlockFilesystem::new(&mut fs);
+
+        write::img::create_xdvdfs_image(
+            &PathBuf::from("/"),
+            &mut slbfs,
+            &mut slbd,
+            progress_callback,
+        )
+        .await?;
+
+        let mut input = write::fs::CisoSectorInput::new(slbd, slbfs);
+        ciso::write::write_ciso_image(&mut input, &mut output, progress_callback_compression)
+            .await
+            .unwrap();
+    } else {
+        return Err(anyhow::anyhow!("Symlink image sources are not supported"));
+    }
+
+    Ok(())
+}

--- a/xdvdfs-cli/src/cmd_info.rs
+++ b/xdvdfs-cli/src/cmd_info.rs
@@ -51,7 +51,7 @@ fn print_dirent(dirent: &DirectoryEntryNode) -> Result<(), anyhow::Error> {
 
 #[maybe_async(?Send)]
 pub async fn cmd_info(img_path: &String, entry: Option<&String>) -> Result<(), anyhow::Error> {
-    let mut img = crate::cmd_read::open_image(Path::new(img_path)).await?;
+    let mut img = crate::img::open_image(Path::new(img_path)).await?;
     let volume = xdvdfs::read::read_volume(&mut img).await?;
 
     match entry {

--- a/xdvdfs-cli/src/cmd_pack.rs
+++ b/xdvdfs-cli/src/cmd_pack.rs
@@ -49,8 +49,10 @@ pub async fn cmd_pack(
         write::img::create_xdvdfs_image(&source_path, &mut fs, &mut image, progress_callback)
             .await?;
     } else if meta.is_file() {
-        let source = crate::cmd_read::open_image(&source_path).await?;
-        let mut fs = write::fs::XDVDFSFilesystem::new(source).await.unwrap();
+        let source = crate::img::open_image_raw(&source_path).await?;
+        let mut fs = write::fs::XDVDFSFilesystem::new(source)
+            .await
+            .ok_or(anyhow::anyhow!("Failed to create XDVDFS filesystem"))?;
         write::img::create_xdvdfs_image(
             &PathBuf::from("/"),
             &mut fs,

--- a/xdvdfs-cli/src/cmd_read.rs
+++ b/xdvdfs-cli/src/cmd_read.rs
@@ -1,21 +1,11 @@
+use crate::img::{open_image, open_image_raw};
 use maybe_async::maybe_async;
 use std::{
     fs::File,
-    io::{BufReader, Read, Write},
+    io::{Read, Write},
     path::{Path, PathBuf},
     str::FromStr,
 };
-use xdvdfs::blockdev::OffsetWrapper;
-
-#[maybe_async(?Send)]
-#[maybe_async(?Send)]
-pub async fn open_image(
-    path: &Path,
-) -> Result<OffsetWrapper<BufReader<File>, std::io::Error>, anyhow::Error> {
-    let img = File::options().read(true).open(path)?;
-    let img = std::io::BufReader::new(img);
-    Ok(xdvdfs::blockdev::OffsetWrapper::new(img).await?)
-}
 
 #[maybe_async(?Send)]
 pub async fn cmd_ls(img_path: &str, dir_path: &str) -> Result<(), anyhow::Error> {
@@ -112,7 +102,7 @@ pub async fn cmd_unpack(img_path: &str, target_dir: &Option<String>) -> Result<(
         }
     };
 
-    let mut img = open_image(Path::new(img_path)).await?;
+    let mut img = open_image_raw(Path::new(img_path)).await?;
     let volume = xdvdfs::read::read_volume(&mut img).await?;
     let tree = volume.root_table.file_tree(&mut img).await?;
 

--- a/xdvdfs-cli/src/img.rs
+++ b/xdvdfs-cli/src/img.rs
@@ -1,0 +1,73 @@
+use ciso::read::CSOReader;
+use maybe_async::maybe_async;
+use std::{fs::File, io::BufReader, path::Path};
+use xdvdfs::blockdev::{BlockDeviceRead, OffsetWrapper};
+
+pub struct CSOBlockDevice<R: ciso::read::Read<std::io::Error>> {
+    inner: CSOReader<std::io::Error, R>,
+}
+
+#[maybe_async(?Send)]
+impl<R> BlockDeviceRead<std::io::Error> for CSOBlockDevice<R>
+where
+    R: ciso::read::Read<std::io::Error>,
+{
+    async fn read(&mut self, offset: u64, buffer: &mut [u8]) -> Result<(), std::io::Error> {
+        self.inner
+            .read_offset(offset, buffer)
+            .await
+            .map_err(|e| match e {
+                ciso::layout::Error::Other(e) => e,
+                e => std::io::Error::new(std::io::ErrorKind::Other, e),
+            })
+    }
+}
+
+#[maybe_async(?Send)]
+pub async fn open_image_raw(
+    path: &Path,
+) -> Result<OffsetWrapper<BufReader<File>, std::io::Error>, anyhow::Error> {
+    let img = File::options().read(true).open(path)?;
+    let img = std::io::BufReader::new(img);
+    Ok(xdvdfs::blockdev::OffsetWrapper::new(img).await?)
+}
+
+#[maybe_async(?Send)]
+pub async fn open_image(
+    path: &Path,
+) -> Result<Box<dyn BlockDeviceRead<std::io::Error>>, anyhow::Error> {
+    if path.extension().is_some_and(|e| e == "cso") {
+        let file_base = path.with_extension("");
+        let split = file_base.extension().is_some_and(|e| e == "1");
+
+        let reader: Box<dyn ciso::read::Read<std::io::Error>> = if split {
+            let mut files = Vec::new();
+            for i in 1.. {
+                let part = file_base.with_extension(format!("{}.cso", i));
+                if !part.exists() {
+                    break;
+                }
+
+                let part = std::io::BufReader::new(std::fs::File::open(part)?);
+                files.push(part);
+            }
+
+            if files.is_empty() {
+                return Err(anyhow::anyhow!("Failed to open file {:?}", path));
+            }
+
+            Box::from(ciso::split::SplitFileReader::new(files).await?)
+        } else {
+            let file = std::io::BufReader::new(std::fs::File::open(path)?);
+            Box::from(file)
+        };
+
+        let reader = ciso::read::CSOReader::new(reader).await?;
+        let reader = Box::from(CSOBlockDevice { inner: reader });
+        Ok(reader)
+    } else {
+        let image = open_image_raw(path).await?;
+        let image = Box::from(image);
+        Ok(image)
+    }
+}

--- a/xdvdfs-cli/src/main.rs
+++ b/xdvdfs-cli/src/main.rs
@@ -1,10 +1,12 @@
 use clap::{Parser, Subcommand};
 use maybe_async::maybe_async;
 
+mod cmd_compress;
 mod cmd_info;
 mod cmd_md5;
 mod cmd_pack;
 mod cmd_read;
+mod img;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None, arg_required_else_help = true)]
@@ -71,6 +73,14 @@ enum Cmd {
         #[arg(help = "Path to output image")]
         image_path: Option<String>,
     },
+    #[command(about = "Pack and compress an image from a given directory or source ISO image")]
+    Compress {
+        #[arg(help = "Path to source directory or ISO image")]
+        source_path: String,
+
+        #[arg(help = "Path to output image")]
+        image_path: Option<String>,
+    },
 }
 
 #[maybe_async]
@@ -90,6 +100,10 @@ async fn run_command(cmd: &Cmd) -> Result<(), anyhow::Error> {
             source_path,
             image_path,
         } => cmd_pack::cmd_pack(source_path, image_path).await,
+        Compress {
+            source_path,
+            image_path,
+        } => cmd_compress::cmd_compress(source_path, image_path).await,
     }
 }
 

--- a/xdvdfs-core/Cargo.toml
+++ b/xdvdfs-core/Cargo.toml
@@ -25,15 +25,17 @@ maybe-async = "0.2.7"
 arrayvec = { version = "0.7.2", default-features = false, optional = true}
 log = { version = "0.4.17", optional = true }
 sha3 = { version = "0.10.8", optional = true, default-features = false }
+ciso = { version = "0.1.0", default-features = false, optional = true }
 
 [features]
-default = ["std", "read", "write", "logging", "checksum"]
+default = ["std", "read", "write", "logging", "checksum", "ciso_support"]
 std = ["serde/std", "arrayvec/std", "sha3/std"]
 read = []
 write = ["std", "arrayvec"]
 logging = ["log"]
-sync = ["maybe-async/is_sync"]
+sync = ["maybe-async/is_sync", "ciso/sync"]
 checksum = ["sha3"]
+ciso_support = ["write", "ciso"]
 
 [lib]
 

--- a/xdvdfs-core/src/write/dirtab.rs
+++ b/xdvdfs-core/src/write/dirtab.rs
@@ -21,6 +21,7 @@ pub struct DirectoryEntryTableWriter {
 pub struct FileListingEntry {
     pub name: String,
     pub sector: u64,
+    pub size: u64,
     pub is_dir: bool,
 }
 
@@ -182,6 +183,7 @@ impl DirectoryEntryTableWriter {
             file_listing.push(FileListingEntry {
                 name: node.data().name_str().to_string(),
                 sector,
+                size: dirent.dirent.data.size as u64,
                 is_dir: dirent.dirent.attributes.directory(),
             });
 

--- a/xdvdfs-core/src/write/img.rs
+++ b/xdvdfs-core/src/write/img.rs
@@ -158,8 +158,13 @@ pub async fn create_xdvdfs_image<H: BlockDeviceWrite<E>, E>(
             if entry.is_dir {
                 dir_sectors.insert(file_path.clone(), entry.sector);
             } else {
-                fs.copy_file_in(&file_path, image, entry.sector * layout::SECTOR_SIZE)
-                    .await?;
+                fs.copy_file_in(
+                    &file_path,
+                    image,
+                    entry.sector * layout::SECTOR_SIZE,
+                    entry.size,
+                )
+                .await?;
             }
         }
     }

--- a/xdvdfs-web/Cargo.toml
+++ b/xdvdfs-web/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["**/*.iso", "**/*.xiso"]
 [dependencies]
 async-recursion = "1.0.4"
 async-trait = "0.1.68"
+ciso = { version = "0.1.0", default-features = false }
 implicit-clone = "0.3.5"
 js-sys = "0.3.61"
 log = "0.4.17"
@@ -23,6 +24,6 @@ wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"
 wasm-logger = "0.2.0"
 web-sys = { version = "0.3.61", features = ["WritableStream", "MediaQueryList", "Window"] }
-xdvdfs = { path = "../xdvdfs-core", version = "0.5.2" }
+xdvdfs = { path = "../xdvdfs-core", version = "0.6.0" }
 yew = { version = "0.20.0", features = ["csr"] }
 yewprint = "0.4.4"

--- a/xdvdfs-web/src/compress.rs
+++ b/xdvdfs-web/src/compress.rs
@@ -1,0 +1,398 @@
+use std::path::PathBuf;
+
+use crate::fs::{FSWriteWrapper, FileSystemDirectoryHandle};
+
+use super::fs;
+use super::picker::{FilePickerButton, PickerKind, PickerResult};
+use xdvdfs::write::img::ProgressInfo;
+
+use yew::prelude::*;
+use yewprint::{Button, ButtonGroup, Callout, Icon, Intent, ProgressBar, H5};
+
+#[derive(PartialEq, PartialOrd, Copy, Clone)]
+pub enum ImageCreationState {
+    CreatingFilesystem,
+    PackingImage,
+    WaitingForFlush,
+}
+
+impl ImageCreationState {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::CreatingFilesystem => "Creating filesystem",
+            Self::PackingImage => "Packing image",
+            Self::WaitingForFlush => "Waiting for browser to release output file",
+        }
+    }
+}
+
+#[derive(Default, PartialEq, PartialOrd, Clone)]
+#[repr(u8)]
+pub enum WorkflowState {
+    #[default]
+    SelectInputType = 0,
+
+    SelectInput = 1,
+
+    SelectOutput = 2,
+    Packing(ImageCreationState) = 3,
+    Compressing = 4,
+    Finished = 5,
+    Error(String) = 6,
+}
+
+impl WorkflowState {
+    fn is_at_least(&self, other: Self) -> bool {
+        self >= &other
+    }
+
+    fn is_packing_and(&self, cb: impl FnOnce(ImageCreationState) -> bool) -> bool {
+        if let Self::Packing(ics) = self {
+            cb(*ics)
+        } else {
+            false
+        }
+    }
+
+    fn is_at_least_packing(&self) -> bool {
+        if let Self::Packing(_) = self {
+            true
+        } else {
+            self >= &Self::Compressing
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        match self {
+            Self::SelectInputType => "Select input type",
+            Self::SelectInput => "Select input",
+            Self::SelectOutput => "Select output",
+            Self::Packing(ics) => ics.as_str(),
+            Self::Compressing => "Compressing image (this may take a while)",
+            Self::Finished => "Finished",
+            Self::Error(_) => "Errored",
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum InputHandleType {
+    Directory,
+    File,
+}
+
+impl InputHandleType {
+    fn to_picker_kind(self) -> PickerKind {
+        match self {
+            Self::File => PickerKind::OpenFile,
+            Self::Directory => PickerKind::OpenDirectory,
+        }
+    }
+
+    fn to_str(self) -> &'static str {
+        match self {
+            Self::File => "ISO image",
+            Self::Directory => "folder",
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct ImageBuilderWorkflow {
+    workflow_state: WorkflowState,
+
+    input_handle_type: Option<InputHandleType>,
+    input_handle: Option<PickerResult>,
+    output_dir_handle: Option<FileSystemDirectoryHandle>,
+
+    packing_file_count: u32,
+    packing_file_progress: u32,
+    packing_file_name: Option<String>,
+}
+
+pub enum WorkflowMessage {
+    DoNothing,
+    UpdateProgress(ProgressInfo),
+    UpdateCompressionProgress(ciso::write::ProgressInfo),
+    SetInputType(InputHandleType),
+    SetInput(PickerResult),
+    SetOutputFile(FileSystemDirectoryHandle),
+    ChangeState(WorkflowState),
+}
+
+impl ImageBuilderWorkflow {
+    fn reset_state(&mut self, workflow_state: u8) {
+        if workflow_state == 0 {
+            self.input_handle_type = None;
+        }
+
+        if workflow_state <= 1 {
+            self.input_handle = None;
+        }
+
+        if workflow_state <= 2 {
+            self.output_dir_handle = None;
+        }
+
+        if workflow_state <= 3 {
+            self.packing_file_count = 0;
+            self.packing_file_progress = 0;
+            self.packing_file_name = None;
+        }
+    }
+
+    fn input_name(&self) -> Option<String> {
+        self.input_handle.as_ref().map(|ih| match ih {
+            PickerResult::DirectoryHandle(dh) => dh.name(),
+            PickerResult::FileHandle(fh) => fh.name(),
+        })
+    }
+}
+
+impl Component for ImageBuilderWorkflow {
+    type Message = WorkflowMessage;
+    type Properties = ();
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let is_packing = self.workflow_state.is_packing_and(|_| true);
+        let progress = if self.packing_file_count != 0 {
+            (100 * self.packing_file_progress) / self.packing_file_count
+        } else {
+            0
+        };
+
+        html! {
+            <div>
+                <Callout intent={if self.workflow_state == WorkflowState::SelectInputType { Intent::Primary } else { Intent::Success }}>
+                    <H5>{"Select the input source type"}</H5>
+                    <ButtonGroup>
+                        <Button
+                            icon={Icon::FolderClose}
+                            disabled={is_packing}
+                            onclick={ctx.link().callback(|_| WorkflowMessage::SetInputType(InputHandleType::Directory))}
+                        >{"Folder"}</Button>
+                        <Button
+                            icon={Icon::Document}
+                            disabled={is_packing}
+                            onclick={ctx.link().callback(|_| WorkflowMessage::SetInputType(InputHandleType::File))}
+                        >{"ISO Image"}</Button>
+                    </ButtonGroup>
+                </Callout>
+                if self.workflow_state.is_at_least(WorkflowState::SelectInput) {
+                    <Callout intent={if self.workflow_state == WorkflowState::SelectInput { Intent::Primary } else { Intent::Success }}>
+                        <H5>{format!("Select an input {} containing Xbox software to pack", self.input_handle_type.unwrap().to_str())}</H5>
+                        <div>
+                            <FilePickerButton
+                                kind={self.input_handle_type.unwrap().to_picker_kind()}
+                                button_text={format!("Select {}", self.input_handle_type.unwrap().to_str())}
+                                disabled={is_packing}
+                                setter={ctx.link().callback(WorkflowMessage::SetInput)}
+                            />
+                            if let Some(name) = self.input_name() {
+                                {format!("Selected: {}", name)}
+                            }
+                        </div>
+                    </Callout>
+                }
+                if self.workflow_state.is_at_least(WorkflowState::SelectOutput) {
+                    <Callout intent={if self.workflow_state == WorkflowState::SelectOutput { Intent::Primary } else { Intent::Success }}>
+                        <H5>{"Select folder to output CISO parts"}</H5>
+                        <div>
+                            <FilePickerButton
+                                kind={PickerKind::OpenDirectory}
+                                button_text={"Select output directory"}
+                                disabled={is_packing}
+                                setter={ctx.link().callback(|res| {
+                                    if let PickerResult::DirectoryHandle(dh) = res {
+                                        WorkflowMessage::SetOutputFile(dh)
+                                    } else {
+                                        WorkflowMessage::DoNothing
+                                    }
+                                })}
+                            />
+                            if let Some(ref dh) = self.output_dir_handle {
+                                {format!("Selected: {}", dh.name())}
+                            }
+                        </div>
+                    </Callout>
+                }
+            if self.workflow_state.is_at_least_packing() {
+                <Callout intent={match self.workflow_state {
+                    WorkflowState::Finished => Intent::Success,
+                    WorkflowState::Error(_) => Intent::Danger,
+                    _ => Intent::Primary,
+                }}>
+                    <H5>{"Generating CISO Image"}</H5>
+                    <ProgressBar
+                        value={progress}
+                        animate=true
+                        stripes={self.workflow_state.is_packing_and(|ics| ics == ImageCreationState::WaitingForFlush) || self.workflow_state == WorkflowState::Compressing}
+                    />
+                    {self.workflow_state.as_str()}
+                    <br/>
+                    if let WorkflowState::Error(ref e) = self.workflow_state {
+                        {e}
+                    } else if let WorkflowState::Compressing = self.workflow_state {
+                        {format!("Compressing sector {} of {}", self.packing_file_progress, self.packing_file_count)}
+                    } else {
+                        {format!("Packing {} of {} files", self.packing_file_progress, self.packing_file_count)}
+                    }
+                        <br />
+                        if let Some(ref name) = self.packing_file_name {
+                            {format!("Packing {}", name)}
+                        }
+                    //}
+                </Callout>
+            }
+            </div>
+        }
+    }
+
+    fn create(_ctx: &Context<Self>) -> Self {
+        Self::default()
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            WorkflowMessage::DoNothing => {}
+            WorkflowMessage::SetInputType(it) => {
+                self.reset_state(0);
+                self.input_handle_type = Some(it);
+                self.workflow_state = WorkflowState::SelectInput;
+            }
+            WorkflowMessage::SetInput(input) => {
+                self.reset_state(1);
+                self.input_handle = Some(input);
+                self.workflow_state = WorkflowState::SelectOutput;
+            }
+            WorkflowMessage::SetOutputFile(dh) => {
+                self.reset_state(2);
+                self.output_dir_handle = Some(dh.clone());
+                self.workflow_state =
+                    WorkflowState::Packing(ImageCreationState::CreatingFilesystem);
+
+                wasm_bindgen_futures::spawn_local(create_image(
+                    self.input_handle.clone().unwrap(),
+                    dh,
+                    ctx.link().callback(WorkflowMessage::UpdateProgress),
+                    ctx.link()
+                        .callback(WorkflowMessage::UpdateCompressionProgress),
+                    ctx.link().callback(WorkflowMessage::ChangeState),
+                ));
+            }
+            WorkflowMessage::UpdateProgress(pi) => match pi {
+                ProgressInfo::FinishedPacking => {
+                    self.workflow_state =
+                        WorkflowState::Packing(ImageCreationState::WaitingForFlush);
+                }
+                ProgressInfo::FileCount(total) => self.packing_file_count = total as u32,
+                ProgressInfo::FileAdded(path, size) => {
+                    self.packing_file_name = Some(format!("{:?} ({} bytes)", path, size));
+                    self.packing_file_progress += 1;
+                }
+                _ => {}
+            },
+            WorkflowMessage::UpdateCompressionProgress(pi) => match pi {
+                ciso::write::ProgressInfo::SectorCount(count) => {
+                    self.packing_file_count = count as u32;
+                    self.packing_file_name = None;
+                    self.packing_file_progress = 0;
+                }
+                ciso::write::ProgressInfo::SectorFinished => {
+                    self.packing_file_progress += 1;
+                }
+                _ => {}
+            },
+            WorkflowMessage::ChangeState(wfs) => self.workflow_state = wfs,
+        }
+
+        true
+    }
+
+    fn changed(&mut self, _ctx: &Context<Self>, _old_props: &Self::Properties) -> bool {
+        true
+    }
+}
+
+async fn create_image_result(
+    src: PickerResult,
+    dest: FileSystemDirectoryHandle,
+    progress_callback: yew::Callback<ProgressInfo, ()>,
+    compression_progress_callback: yew::Callback<ciso::write::ProgressInfo, ()>,
+    state_change_callback: &yew::Callback<WorkflowState, ()>,
+) -> Result<(), String> {
+    let (mut fs, name): (
+        Box<dyn xdvdfs::write::fs::Filesystem<FSWriteWrapper, String>>,
+        String,
+    ) = match src {
+        PickerResult::DirectoryHandle(dh) => {
+            let name = dh.name();
+            (Box::new(fs::WebFileSystem::new(dh).await), name)
+        }
+        PickerResult::FileHandle(fh) => {
+            let name = fh.name();
+            let img = xdvdfs::blockdev::OffsetWrapper::new(fh).await?;
+            let fs = xdvdfs::write::fs::XDVDFSFilesystem::new(img)
+                .await
+                .ok_or(String::from("Failed to create fs"))?;
+            (Box::new(fs), name)
+        }
+    };
+
+    state_change_callback.emit(WorkflowState::Packing(ImageCreationState::PackingImage));
+
+    let mut slbd = xdvdfs::write::fs::SectorLinearBlockDevice::default();
+    let mut slbfs: xdvdfs::write::fs::SectorLinearBlockFilesystem<
+        String,
+        FSWriteWrapper,
+        Box<dyn xdvdfs::write::fs::Filesystem<FSWriteWrapper, String>>,
+    > = xdvdfs::write::fs::SectorLinearBlockFilesystem::new(&mut fs);
+
+    xdvdfs::write::img::create_xdvdfs_image(
+        &std::path::PathBuf::from("/"),
+        &mut slbfs,
+        &mut slbd,
+        |pi| progress_callback.emit(pi),
+    )
+    .await?;
+
+    state_change_callback.emit(WorkflowState::Compressing);
+
+    let output = crate::fs::ciso::CisoOutputDirectory::new(dest);
+    let mut output = ciso::split::SplitOutput::new(output, PathBuf::from(name));
+    let mut input = xdvdfs::write::fs::CisoSectorInput::new(slbd, slbfs);
+    ciso::write::write_ciso_image(&mut input, &mut output, |pi| {
+        compression_progress_callback.emit(pi)
+    })
+    .await
+    .map_err(|e| format!("{:?}", e))?;
+
+    state_change_callback.emit(WorkflowState::Packing(ImageCreationState::WaitingForFlush));
+
+    output.close().await;
+
+    Ok(())
+}
+
+async fn create_image(
+    src: PickerResult,
+    dest: FileSystemDirectoryHandle,
+    progress_callback: yew::Callback<ProgressInfo, ()>,
+    compression_progress_callback: yew::Callback<ciso::write::ProgressInfo, ()>,
+    state_change_callback: yew::Callback<WorkflowState, ()>,
+) {
+    let result = create_image_result(
+        src,
+        dest,
+        progress_callback,
+        compression_progress_callback,
+        &state_change_callback,
+    )
+    .await;
+    let state = match result {
+        Ok(_) => WorkflowState::Finished,
+        Err(e) => WorkflowState::Error(e),
+    };
+
+    state_change_callback.emit(state);
+}

--- a/xdvdfs-web/src/fs/bindings.rs
+++ b/xdvdfs-web/src/fs/bindings.rs
@@ -57,6 +57,9 @@ extern "C" {
         opts: FileOptions,
     ) -> js_sys::Promise;
 
+    #[wasm_bindgen(method, structural, js_class = "FileSystemDirectoryHandle", js_name = removeEntry)]
+    pub fn remove_entry_promise(this: &FileSystemDirectoryHandle, name: String) -> js_sys::Promise;
+
     #[wasm_bindgen(extends = FileSystemHandle, extends = Object, js_name = FileSystemFileHandle, typescript_type = "FileSystemFileHandle")]
     #[derive(Clone, PartialEq, Eq)]
     pub type FileSystemFileHandle;

--- a/xdvdfs-web/src/fs/ciso.rs
+++ b/xdvdfs-web/src/fs/ciso.rs
@@ -1,0 +1,74 @@
+use std::ffi::OsStr;
+
+use async_trait::async_trait;
+use ciso::{
+    split::SplitFilesystem,
+    write::{AsyncWriter, SectorReader},
+};
+use xdvdfs::blockdev::BlockDeviceWrite;
+
+use super::{FSWriteWrapper, FileSystemDirectoryHandle, FileSystemFileHandle};
+
+pub struct CisoOutputDirectory {
+    dir: FileSystemDirectoryHandle,
+}
+
+impl CisoOutputDirectory {
+    pub fn new(dir: FileSystemDirectoryHandle) -> Self {
+        Self { dir }
+    }
+}
+
+#[async_trait(?Send)]
+impl SplitFilesystem<String, FSWriteWrapper> for CisoOutputDirectory {
+    async fn create_file(&mut self, name: &OsStr) -> Result<FSWriteWrapper, String> {
+        let name = name.to_str().ok_or("Failed to convert name to string")?;
+        let file = self
+            .dir
+            .create_file(name.to_owned())
+            .await
+            .map_err(|_| "Failed to create file")?;
+        let file = FSWriteWrapper::new(&file).await;
+        Ok(file)
+    }
+
+    async fn close(&mut self, f: FSWriteWrapper) {
+        f.close().await;
+    }
+}
+
+#[async_trait(?Send)]
+impl AsyncWriter<String> for FSWriteWrapper {
+    async fn atomic_write(&mut self, position: u64, data: &[u8]) -> Result<(), String> {
+        BlockDeviceWrite::write(self, position, data).await
+    }
+}
+
+#[async_trait(?Send)]
+impl SectorReader<String> for FileSystemFileHandle {
+    async fn size(&mut self) -> Result<u64, String> {
+        let file = self.to_file().await?;
+        Ok(file.size() as u64)
+    }
+
+    async fn read_sector(&mut self, sector: usize, sector_size: u32) -> Result<Vec<u8>, String> {
+        let file = self.to_file().await?;
+        let offset: f64 = (sector as f64) * (sector_size as f64);
+        let mut buf: Vec<u8> = vec![0; sector_size as usize];
+
+        let slice = file
+            .slice_with_f64_and_f64_and_content_type(
+                offset,
+                offset + sector_size as f64,
+                "application/octet-stream",
+            )
+            .map_err(|_| "failed to slice")?;
+        let slice_buf = wasm_bindgen_futures::JsFuture::from(slice.array_buffer())
+            .await
+            .map_err(|_| "failed to obtain array buffer")?;
+        let slice_buf = js_sys::Uint8Array::new(&slice_buf);
+        slice_buf.copy_to(&mut buf);
+
+        Ok(buf)
+    }
+}

--- a/xdvdfs-web/src/fs/util.rs
+++ b/xdvdfs-web/src/fs/util.rs
@@ -95,4 +95,10 @@ impl FileSystemDirectoryHandle {
         let handle = wasm_bindgen_futures::JsFuture::from(handle).await?;
         Ok(FileSystemDirectoryHandle::from(handle))
     }
+
+    pub async fn remove_entry(&self, name: String) -> Result<(), JsValue> {
+        let promise = self.remove_entry_promise(name);
+        wasm_bindgen_futures::JsFuture::from(promise).await?;
+        Ok(())
+    }
 }

--- a/xdvdfs-web/src/main.rs
+++ b/xdvdfs-web/src/main.rs
@@ -1,6 +1,7 @@
 use implicit_clone::{unsync::IArray, ImplicitClone};
 use yew::prelude::*;
 
+mod compress;
 mod fs;
 mod info;
 mod packing;
@@ -13,6 +14,7 @@ use yewprint::{Callout, Intent, Tab, Tabs};
 enum XisoTool {
     Packer,
     Unpacker,
+    Compressor,
 }
 
 impl ImplicitClone for XisoTool {}
@@ -46,6 +48,14 @@ fn XisoToolTab() -> Html {
                     id: XisoTool::Unpacker,
                     title: html!{"Unpack"},
                     panel: html!{ <unpacking::ImageUnpackingWorkflow /> },
+                    panel_class: Classes::default(),
+                    title_class: Classes::default(),
+                },
+                Tab {
+                    disabled: false,
+                    id: XisoTool::Compressor,
+                    title: html!{"Compress"},
+                    panel: html!{ <compress::ImageBuilderWorkflow /> },
                     panel_class: Classes::default(),
                     title_class: Classes::default(),
                 },


### PR DESCRIPTION
Adds support for CISO image creation and usage to xdvdfs-cli and xdvdfs-web. Some utilities are added in core under
the ciso_support feature flag.

Under the changes, the CLI can take cso images into most commands. The `compress` subcommand allows for creating
cso images. The website also has an added tab for creating compressed images.

Resolves #44 
