### PR TITLE
core: Correctly handle empty dirtabs with nonzero size

### DIFF
--- a/xdvdfs-core/src/read.rs
+++ b/xdvdfs-core/src/read.rs
@@ -34,8 +34,8 @@ async fn read_dirent<E>(
         .await
         .map_err(|e| util::Error::IOError(e))?;
 
-    // Empty directory entries are filled with 0xff
-    if dirent_buf == [0xff; 0xe] {
+    // Empty directory entries are filled with 0xff or 0x00
+    if dirent_buf == [0xff; 0xe] || dirent_buf == [0x00; 0xe] {
         return Ok(None);
     }
 

--- a/xdvdfs-core/src/write/avl.rs
+++ b/xdvdfs-core/src/write/avl.rs
@@ -625,7 +625,7 @@ mod test {
     fn test_preorder_backend_ordering_large_data() {
         let mut rng = rngs::StdRng::seed_from_u64(0x5842_4f58_5842_4f58);
         let mut test_set: Vec<i32> = Vec::new();
-        test_set.resize_with(100, || rng.gen());
+        test_set.resize_with(1000, || rng.gen());
 
         let mut tree = AvlTree::default();
 

--- a/xdvdfs-core/src/write/dirtab.rs
+++ b/xdvdfs-core/src/write/dirtab.rs
@@ -121,6 +121,13 @@ impl DirectoryEntryTableWriter {
         mut self,
         allocator: &mut SectorAllocator,
     ) -> Result<DirectoryEntryTableDiskRepr, util::Error<E>> {
+        if self.table.backing_vec().is_empty() {
+            return Ok(DirectoryEntryTableDiskRepr {
+                entry_table: alloc::vec![0xff; 2048].into_boxed_slice(),
+                file_listing: Vec::new(),
+            });
+        }
+
         self.table.reorder_backing_preorder();
 
         // Array of offsets for each entry in the table


### PR DESCRIPTION
Reproducer is to create an empty directory and repack the image twice.

Fixes #64 