### PR TITLE
core: Remove unexpected error and related unnecessary casting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/antangelo/xdvdfs"
 homepage = "https://github.com/antangelo/xdvdfs"

--- a/xdvdfs-cli/Cargo.toml
+++ b/xdvdfs-cli/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 exclude = ["**/*.iso", "**/*.xiso"]
 
 [dependencies]
-xdvdfs = { path = "../xdvdfs-core", version = "0.7.0" }
+xdvdfs = { path = "../xdvdfs-core", version = "0.8.0" }
 clap = { version = "4.2.1", features = ["derive"] }
 md-5 = { version = "0.10.5", default-features = false }
 futures = "0.3.28"

--- a/xdvdfs-core/src/layout.rs
+++ b/xdvdfs-core/src/layout.rs
@@ -9,7 +9,7 @@ use serde_big_array::BigArray;
 
 use maybe_async::maybe_async;
 
-pub const SECTOR_SIZE: u64 = 2048;
+pub const SECTOR_SIZE: u32 = 2048;
 pub const VOLUME_HEADER_MAGIC: [u8; 0x14] = *b"MICROSOFT*XBOX*MEDIA";
 
 /// Represents a contiguous region on the disk image, given by sector number and
@@ -126,7 +126,7 @@ impl DiskRegion {
             return Err(util::Error::SizeOutOfBounds(offset, self.size));
         }
 
-        let offset = SECTOR_SIZE * self.sector as u64 + offset as u64;
+        let offset = SECTOR_SIZE as u64 * self.sector as u64 + offset as u64;
         Ok(offset)
     }
 }
@@ -326,9 +326,9 @@ impl DirectoryEntryData {
 
     /// Returns the length (in bytes) of the directory entry
     /// on disk, after serialization
-    pub fn len_on_disk<E>(&self) -> Result<u64, util::Error<E>> {
+    pub fn len_on_disk<E>(&self) -> Result<u32, util::Error<E>> {
         let encoded_filename_len = self.encode_name(&mut [0; 256])?;
-        let mut size = (0xe + encoded_filename_len) as u64;
+        let mut size = 0xe + (encoded_filename_len as u32);
 
         if size % 4 > 0 {
             size += 4 - size % 4;

--- a/xdvdfs-core/src/read.rs
+++ b/xdvdfs-core/src/read.rs
@@ -12,7 +12,7 @@ pub async fn read_volume<E>(
     dev: &mut impl BlockDeviceRead<E>,
 ) -> Result<VolumeDescriptor, util::Error<E>> {
     let mut buffer = [0; core::mem::size_of::<VolumeDescriptor>()];
-    dev.read(layout::SECTOR_SIZE * 32, &mut buffer)
+    dev.read(layout::SECTOR_SIZE as u64 * 32, &mut buffer)
         .await
         .map_err(|_| util::Error::InvalidVolume)?;
 

--- a/xdvdfs-core/src/util.rs
+++ b/xdvdfs-core/src/util.rs
@@ -15,7 +15,7 @@ pub enum Error<E> {
     NameTooLong,
     InvalidFileName,
     TooManyDirectoryEntries,
-    Unexpected(alloc::string::String),
+    FileTooLarge,
 }
 
 impl<E> Error<E> {
@@ -33,7 +33,7 @@ impl<E> Error<E> {
             Self::NameTooLong => "File name is too long",
             Self::InvalidFileName => "Invalid file name",
             Self::TooManyDirectoryEntries => "Too many entries in directory",
-            Self::Unexpected(_) => "Unexpected error",
+            Self::FileTooLarge => "File is too large",
         }
     }
 }
@@ -52,10 +52,6 @@ impl<E: Display> Display for Error<E> {
                 f.write_str("Serialization failed: ")?;
                 Display::fmt(e, f)
             }
-            Self::Unexpected(s) => {
-                f.write_str("Unexpected error: ")?;
-                f.write_str(s)
-            }
             other => f.write_str(other.to_str()),
         }
     }
@@ -73,18 +69,6 @@ impl<E: Debug + Display> std::error::Error for Error<E> {}
 impl<E> From<E> for Error<E> {
     fn from(value: E) -> Self {
         Self::IOError(value)
-    }
-}
-
-pub(crate) trait ToUnexpectedError<T, E> {
-    fn or_unexpected(self) -> Result<T, Error<E>>;
-}
-
-impl<T, V: Debug, E> ToUnexpectedError<T, E> for Result<T, V> {
-    fn or_unexpected(self) -> Result<T, Error<E>> {
-        // FIXME: Add feature to disable this and just use an empty string or something
-        // to avoid pulling in formatting code
-        self.map_err(|e| Error::Unexpected(alloc::format!("{:?}", e)))
     }
 }
 

--- a/xdvdfs-core/src/write/dirtab.rs
+++ b/xdvdfs-core/src/write/dirtab.rs
@@ -87,7 +87,8 @@ impl DirectoryEntryTableWriter {
                 .preorder_iter()
                 .map(|node| node.len_on_disk())
                 .try_fold(0, |acc: u32, disk_len: Result<u32, util::Error<E>>| {
-                    disk_len.map(|disk_len| acc + disk_len + sector_align(acc as u64, disk_len as u64))
+                    disk_len
+                        .map(|disk_len| acc + disk_len + sector_align(acc as u64, disk_len as u64))
                 })?,
         );
 

--- a/xdvdfs-core/src/write/fs.rs
+++ b/xdvdfs-core/src/write/fs.rs
@@ -324,9 +324,9 @@ impl<E: Send + Sync> BlockDeviceWrite<E> for SectorLinearBlockDevice<E> {
         let mut remaining = buffer.len();
         let mut buffer_pos = 0;
 
-        let mut sector = offset / layout::SECTOR_SIZE;
+        let mut sector = offset / layout::SECTOR_SIZE as u64;
 
-        let offset = offset % layout::SECTOR_SIZE;
+        let offset = offset % layout::SECTOR_SIZE as u64;
         assert_eq!(offset, 0);
 
         while remaining > 0 {
@@ -361,12 +361,12 @@ impl<E: Send + Sync> BlockDeviceWrite<E> for SectorLinearBlockDevice<E> {
             .contents
             .last_key_value()
             .map(|(sector, contents)| {
-                *sector * layout::SECTOR_SIZE
+                *sector * layout::SECTOR_SIZE as u64
                     + match contents {
                         SectorLinearBlockContents::RawData(_) => layout::SECTOR_SIZE,
                         SectorLinearBlockContents::File(_, _) => layout::SECTOR_SIZE,
                         SectorLinearBlockContents::Empty => 0,
-                    }
+                    } as u64
             })
             .unwrap_or(0))
     }
@@ -391,12 +391,12 @@ where
         offset: u64,
         size: u64,
     ) -> Result<u64, E> {
-        let sector = offset / layout::SECTOR_SIZE;
-        let offset = offset % layout::SECTOR_SIZE;
+        let sector = offset / layout::SECTOR_SIZE as u64;
+        let offset = offset % layout::SECTOR_SIZE as u64;
         assert_eq!(offset, 0);
 
-        let mut sector_span = size / layout::SECTOR_SIZE;
-        if size % layout::SECTOR_SIZE > 0 {
+        let mut sector_span = size / layout::SECTOR_SIZE as u64;
+        if size % layout::SECTOR_SIZE as u64 > 0 {
             sector_span += 1;
         }
 

--- a/xdvdfs-core/src/write/img.rs
+++ b/xdvdfs-core/src/write/img.rs
@@ -79,7 +79,10 @@ fn create_dirent_tables<'a, E>(
                     dirtab.add_dir(file_name, dir_size)?;
                 }
                 fs::FileType::File => {
-                    let file_size = entry.len.try_into().map_err(|_| util::Error::FileTooLarge)?;
+                    let file_size = entry
+                        .len
+                        .try_into()
+                        .map_err(|_| util::Error::FileTooLarge)?;
                     dirtab.add_file(file_name, file_size)?;
                 }
             }
@@ -127,10 +130,7 @@ pub async fn create_xdvdfs_image<H: BlockDeviceWrite<E>, E>(
         .expect("should always have one dirent at minimum (root)");
     let root_dirtab_size = root_dirtab.1.dirtab_size();
     let root_sector = sector_allocator.allocate_contiguous(root_dirtab_size as u64);
-    let root_table = layout::DirectoryEntryTable::new(
-        root_dirtab_size,
-        root_sector,
-    );
+    let root_table = layout::DirectoryEntryTable::new(root_dirtab_size, root_sector);
     dir_sectors.insert(root_dirtab.0.to_path_buf(), root_sector as u64);
 
     for (path, dirtab) in dirent_tables.into_iter() {

--- a/xdvdfs-core/src/write/sector.rs
+++ b/xdvdfs-core/src/write/sector.rs
@@ -1,7 +1,7 @@
 use crate::layout::SECTOR_SIZE;
 
 pub struct SectorAllocator {
-    next_free: u64,
+    next_free: u32,
 }
 
 impl Default for SectorAllocator {
@@ -11,9 +11,10 @@ impl Default for SectorAllocator {
     }
 }
 
-pub fn required_sectors(len: u64) -> u64 {
+pub fn required_sectors(len: u64) -> u32 {
     if len != 0 {
-        len / SECTOR_SIZE + if len % SECTOR_SIZE > 0 { 1 } else { 0 }
+        let sectors: u32 = (len / SECTOR_SIZE as u64).try_into().expect("number of sectors should fit in u32");
+        sectors + if (len % SECTOR_SIZE as u64) as u32 > 0 { 1 } else { 0 }
     } else {
         1
     }
@@ -22,7 +23,7 @@ pub fn required_sectors(len: u64) -> u64 {
 impl SectorAllocator {
     /// Allocates a contiguous set of sectors, big enough to fit `bytes`.
     /// Returns the number of the first sector in the allocation
-    pub fn allocate_contiguous(&mut self, bytes: u64) -> u64 {
+    pub fn allocate_contiguous(&mut self, bytes: u64) -> u32 {
         let sectors = required_sectors(bytes);
         let allocation = self.next_free;
         self.next_free += sectors;

--- a/xdvdfs-core/src/write/sector.rs
+++ b/xdvdfs-core/src/write/sector.rs
@@ -13,8 +13,15 @@ impl Default for SectorAllocator {
 
 pub fn required_sectors(len: u64) -> u32 {
     if len != 0 {
-        let sectors: u32 = (len / SECTOR_SIZE as u64).try_into().expect("number of sectors should fit in u32");
-        sectors + if (len % SECTOR_SIZE as u64) as u32 > 0 { 1 } else { 0 }
+        let sectors: u32 = (len / SECTOR_SIZE as u64)
+            .try_into()
+            .expect("number of sectors should fit in u32");
+        sectors
+            + if (len % SECTOR_SIZE as u64) as u32 > 0 {
+                1
+            } else {
+                0
+            }
     } else {
         1
     }

--- a/xdvdfs-desktop/Cargo.toml
+++ b/xdvdfs-desktop/Cargo.toml
@@ -18,7 +18,7 @@ tauri-build = { version = "1.5.0", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.3", features = [ "api-all"] }
-xdvdfs = { path = "../xdvdfs-core", version = "0.7.0" }
+xdvdfs = { path = "../xdvdfs-core", version = "0.8.0" }
 ciso = { version = "0.2.0", default-features = false }
 maybe-async = "0.2.7"
 async-trait = "0.1.75"

--- a/xdvdfs-web/Cargo.toml
+++ b/xdvdfs-web/Cargo.toml
@@ -27,6 +27,6 @@ wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"
 wasm-logger = "0.2.0"
 web-sys = { version = "0.3.61", features = ["WritableStream", "MediaQueryList", "Window"] }
-xdvdfs = { path = "../xdvdfs-core", version = "0.7.0" }
+xdvdfs = { path = "../xdvdfs-core", version = "0.8.0" }
 yew = { version = "0.20.0", features = ["csr"] }
 yewprint = "0.4.4"


### PR DESCRIPTION
Unexpected error was a hack to handle items that would otherwise panic
in xdvdfs-web (as it can't catch panics). The lint is failing on nightly
because it's unused if write is not enabled, which is a great reminder
to remove it.

The majority of the unexpected errors are to handle overflow when
casting down to lower sized integer types, so this commit refactors the
code to remove most of these casts in the first place. The remaining ones
are just allowed to panic (and I don't expect it's likely they'll be run
into anyway).
