### PR TITLE
Add support for Xbox 360 XDVDFS images

### DIFF
--- a/xdvdfs-core/src/blockdev.rs
+++ b/xdvdfs-core/src/blockdev.rs
@@ -3,7 +3,12 @@ use maybe_async::maybe_async;
 #[cfg(not(feature = "sync"))]
 use alloc::boxed::Box;
 
-const XDVD_OFFSETS: &[u64] = &[0, 387 * 1024 * 1024];
+const XDVD_OFFSETS: &[u64] = &[
+    0,         // RAW XISO
+    405798912, // XGD1
+    265879552, // XGD2
+    34078720,  // XGD3
+];
 
 /// Trait for read operations on some block device containing an XDVDFS filesystem
 ///


### PR DESCRIPTION
Adds XGD2 and XGD3 offsets to support Xbox 360 XDVDFS image unpacking. So far, XGD2 and XGD3 support has been tested with the following Redump verified dumps, from my own collection:

XGD2:
- Battle Fantasia
- Halo 3
- Halo Reach
- Forza Motorsport 2
- Forza Motorsport 3
- エスカトス
- 電脳戦機バーチャロン　フォース

XGD3:
- Titanfall
- Battlefield 3, Disc 2

All images from the JAP, or WORLD region; all images produced a valid MD5 repack. 

More testing is needed with known "problematic" images, like games with long paths, long filenames, .xex files at the end of the image, etc. Sadly, I don't happen to own any game that fits the description.