### PR TITLE
all: Split Filesystem trait by Hierarchy/Copier and move errors into associated types

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ name: Check
 jobs:
   check:
     name: Check and lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # FIXME: 24.04 missing libwebkit2gtk-4, required for Tauri
     steps: 
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: zip -j xdvdfs-linux-${{ github.sha }}.zip LICENSE target/release/xdvdfs
       
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xdvdfs-linux-${{ github.sha }}
           path: xdvdfs-linux-${{ github.sha }}.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: zip -j xdvdfs-windows-${{ github.sha }}.zip LICENSE target/x86_64-pc-windows-gnu/release/xdvdfs.exe
       
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xdvdfs-windows-${{ github.sha }}
           path: xdvdfs-windows-${{ github.sha }}.zip
@@ -123,7 +123,7 @@ jobs:
         working-directory: ./xdvdfs-web
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xdvdfs-web-${{ github.sha }}
           path: xdvdfs-web/xdvdfs-web-${{ github.sha }}.zip
@@ -162,7 +162,7 @@ jobs:
           projectPath: ./xdvdfs-desktop
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xdvdfs-desktop-${{ matrix.platform }}-${{ github.sha }}
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "ciso"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42222171e20c6a5e2c83cc5295f4a55c27c9397acff30dbae4f3baeffae47f51"
+checksum = "9b5c2dc8a68635d2030f42d0c1ccd3178ca1aa26462bb558efb6d59329705abf"
 dependencies = [
  "arbitrary-int",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -64,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -79,43 +73,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "anymap2"
@@ -125,19 +120,19 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "arbitrary-int"
-version = "1.2.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84fc003e338a6f69fbd4f7fe9f92b535ff13e9af8997f3b14b6ddff8b1df46d"
+checksum = "825297538d77367557b912770ca3083f778a196054b3ee63b22673c4a3cae0a5"
 
 [[package]]
 name = "arboard"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb4009533e8ff8f1450a5bcbc30f4242a1d34442221f72314bea1f5dc9c7f89"
+checksum = "df099ccb16cd014ff054ac1bf392c67feeef57164b05c42f037cd40f5d4357f4"
 dependencies = [
  "clipboard-win",
  "core-graphics 0.23.2",
- "image 0.25.2",
+ "image 0.25.5",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -156,9 +151,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-broadcast"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -180,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -204,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -234,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.2.4"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a07789659a4d385b79b18b9127fc27e1a59e1e89117c78c5ea3b806f016374"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
  "async-channel",
  "async-io",
@@ -249,7 +244,6 @@ dependencies = [
  "futures-lite",
  "rustix",
  "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -260,7 +254,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -289,13 +283,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -330,23 +324,23 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -378,14 +372,14 @@ dependencies = [
 
 [[package]]
 name = "bitbybit"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb157f9753a7cddfcf4a4f5fed928fbf4ce1b7b64b6bcc121d7a9f95d698997b"
+checksum = "d317eeca82e7d88d606419a430590d83552bdceb899cb29904f63d694344b7fc"
 dependencies = [
  "arbitrary-int",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -396,9 +390,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "block"
@@ -445,9 +439,9 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -456,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -466,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.10.0"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "serde",
@@ -476,15 +470,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -500,9 +494,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
 ]
@@ -543,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.14"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -606,9 +600,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -632,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -642,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -654,21 +648,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clipboard-win"
@@ -717,9 +711,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -752,18 +746,18 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.32"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.32"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -831,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -849,18 +843,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -877,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -915,17 +909,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -949,7 +943,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -960,7 +954,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -981,7 +975,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -994,7 +988,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1033,6 +1027,17 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "dlib"
@@ -1078,9 +1083,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "embed-resource"
-version = "2.4.3"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edcacde9351c33139a41e3c97eb2334351a81a2791bebb0b243df837128f602"
+checksum = "b68b6f9f63a0b6a38bc447d4ce84e2b388f3ec95c99c641c8ff0dd3ef89a6379"
 dependencies = [
  "cc",
  "memchr",
@@ -1098,9 +1103,9 @@ checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -1113,9 +1118,9 @@ checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
+checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -1123,13 +1128,13 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
+checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1153,25 +1158,25 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "error-code"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1180,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -1190,15 +1195,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
@@ -1215,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1233,12 +1238,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1283,7 +1288,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1319,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1334,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1344,15 +1349,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1361,15 +1366,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.3.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1380,32 +1385,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1570,10 +1575,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.29.0"
+name = "getrandom"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gio"
@@ -1652,21 +1669,21 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
 dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1913,7 +1930,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.4.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1928,9 +1945,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -1972,15 +1989,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,7 +2010,7 @@ checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.11",
+ "itoa 1.0.14",
 ]
 
 [[package]]
@@ -2024,9 +2032,9 @@ checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -2042,9 +2050,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2055,7 +2063,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.11",
+ "itoa 1.0.14",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2079,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2102,12 +2110,130 @@ dependencies = [
 
 [[package]]
 name = "ico"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3804960be0bb5e4edb1e1ad67afd321a9ecfd875c3e65c099468fd2717d7cae"
+checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
 dependencies = [
  "byteorder",
  "png",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2127,25 +2253,36 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
 name = "ignore"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
 dependencies = [
  "crossbeam-deque",
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.9",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -2165,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.2"
+version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
+checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -2198,12 +2335,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -2227,19 +2364,19 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2265,9 +2402,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -2320,10 +2457,11 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2380,15 +2518,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -2400,16 +2538,22 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -2423,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "loom"
@@ -2459,9 +2603,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fca4d74ff9dbaac16a01b924bc3693fa2bba0862c2c633abc73f9a8ea21f64"
+checksum = "dce8f34f3717aa37177e723df6c1fc5fb02b2a1087374ea3fe0ea42316dc8f91"
 dependencies = [
  "cc",
  "dirs-next",
@@ -2516,7 +2660,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2567,30 +2711,20 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
- "adler",
+ "adler2",
  "simd-adler32",
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
@@ -2598,9 +2732,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
 dependencies = [
  "libc",
  "log",
@@ -2665,7 +2799,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -2677,7 +2811,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -2702,9 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.11.1"
+version = "4.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a1d03b6305ecefdd9c6c60150179bb8d9f0cd4e64bbcad1e41419e7bf5e414"
+checksum = "96ae13fb6065b0865d2310dfa55ce319245052ed95fbbe2bc87c99962c58d73f"
 dependencies = [
  "log",
  "mac-notification-sys",
@@ -2812,7 +2946,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "block2",
  "libc",
  "objc2",
@@ -2828,7 +2962,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -2848,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
@@ -2858,7 +2992,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "block2",
  "libc",
  "objc2",
@@ -2870,7 +3004,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -2882,7 +3016,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -2909,18 +3043,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "open"
@@ -2934,11 +3068,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -2955,20 +3089,20 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -2988,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.8.2"
+version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+checksum = "6e6520c8cc998c5741ee68ec1dc369fc47e5f0ea5320018ecf2a1ccd6328f48b"
 dependencies = [
  "log",
  "serde",
@@ -3040,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3069,9 +3203,9 @@ dependencies = [
 
 [[package]]
 name = "pathdiff"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -3086,7 +3220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.4.0",
+ "indexmap 2.7.1",
 ]
 
 [[package]]
@@ -3111,12 +3245,12 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.2",
- "phf_shared 0.11.2",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3161,11 +3295,11 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.2",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
 ]
 
@@ -3185,15 +3319,15 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator 0.11.2",
- "phf_shared 0.11.2",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3202,7 +3336,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -3211,43 +3345,43 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -3279,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plist"
@@ -3290,7 +3424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.4.0",
+ "indexmap 2.7.1",
  "quick-xml 0.32.0",
  "serde",
  "time",
@@ -3298,22 +3432,22 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.17.13"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
 ]
 
 [[package]]
 name = "polling"
-version = "3.7.3"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -3396,11 +3530,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit 0.22.23",
 ]
 
 [[package]]
@@ -3435,9 +3569,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -3479,18 +3613,18 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.34.0"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3584,11 +3718,11 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -3604,14 +3738,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3625,13 +3759,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3642,9 +3776,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -3720,24 +3854,24 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3751,15 +3885,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -3772,11 +3906,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3797,7 +3931,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3806,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3836,18 +3970,18 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -3874,23 +4008,23 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
- "indexmap 2.4.0",
- "itoa 1.0.11",
+ "indexmap 2.7.1",
+ "itoa 1.0.14",
  "memchr",
  "ryu",
  "serde",
@@ -3904,14 +4038,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -3923,22 +4057,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.11",
+ "itoa 1.0.14",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.4.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3948,14 +4082,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3977,7 +4111,7 @@ checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3988,17 +4122,6 @@ checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
 dependencies = [
  "nodrop",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -4069,6 +4192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4091,9 +4220,9 @@ checksum = "27207bb65232eda1f588cf46db2fee75c0808d557f6b3cf19a75f5d6d7c94df1"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4193,9 +4322,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4209,10 +4338,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "sys-locale"
-version = "0.3.1"
+name = "synstructure"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801cf239ecd6ccd71f03d270d67dd53d13e90aab208bf4b8fe4ad957ea949b0"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
  "libc",
 ]
@@ -4266,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.16.9"
+version = "0.16.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575c856fc21e551074869dcfaad8f706412bd5b803dfa0fbf6881c4ff4bfafab"
+checksum = "48d298c441a1da46e28e8ad8ec205aab7fd8cd71b9d10e05454224eef422e1ae"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",
@@ -4319,14 +4459,14 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "tar"
-version = "0.4.41"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
 dependencies = [
  "filetime",
  "libc",
@@ -4341,9 +4481,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "1.7.2"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e33e3ba00a3b05eb6c57ef135781717d33728b48acf914bb05629e74d897d29"
+checksum = "e1be4ef682d128826ba4bce70a5cd18b7f5c5803e347835a2c6fed2d6ef3a690"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4362,6 +4502,7 @@ dependencies = [
  "http",
  "ignore",
  "indexmap 1.9.3",
+ "log",
  "nix 0.26.4",
  "notify-rust",
  "objc",
@@ -4370,6 +4511,7 @@ dependencies = [
  "os_info",
  "os_pipe",
  "percent-encoding",
+ "plist",
  "rand 0.8.5",
  "raw-window-handle",
  "regex",
@@ -4400,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fb5a90a64241ddb7217d3210d844149070a911e87e8a107a707a1d4973f164"
+checksum = "2db08694eec06f53625cfc6fff3a363e084e5e9a238166d2989996413c346453"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4419,9 +4561,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a9e3f5cebf779a63bf24903e714ec91196c307d8249a0008b882424328bcda"
+checksum = "53438d78c4a037ffe5eafa19e447eea599bedfb10844cb08ec53c2471ac3ac3f"
 dependencies = [
  "base64 0.21.7",
  "brotli",
@@ -4445,9 +4587,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d0e989f54fe06c5ef0875c5e19cf96453d099a0a774d5192ab47e80471cdab"
+checksum = "233988ac08c1ed3fe794cd65528d48d8f7ed4ab3895ca64cdaa6ad4d00c45c0b"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4459,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33fda7d213e239077fad52e96c6b734cecedb30c2382118b64f94cb5103ff3a"
+checksum = "8066855882f00172935e3fa7d945126580c34dcbabab43f5d4f0c2398a67d47b"
 dependencies = [
  "gtk",
  "http",
@@ -4480,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c447dcd9b0f09c7dc4b752cc33e72788805bfd761fbda5692d30c48289efec"
+checksum = "ce361fec1e186705371f1c64ae9dd2a3a6768bc530d0a2d5e75a634bb416ad4d"
 dependencies = [
  "arboard",
  "cocoa",
@@ -4501,9 +4643,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0c939e88d82903a0a7dfb28388b12a3c03504d6bd6086550edaa3b6d8beaa"
+checksum = "c357952645e679de02cd35007190fcbce869b93ffc61b029f33fe02648453774"
 dependencies = [
  "brotli",
  "ctor",
@@ -4516,7 +4658,7 @@ dependencies = [
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.2",
+ "phf 0.11.3",
  "proc-macro2",
  "quote",
  "semver",
@@ -4552,12 +4694,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4591,22 +4734,22 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4632,12 +4775,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
- "itoa 1.0.11",
+ "itoa 1.0.14",
  "num-conv",
  "powerfmt",
  "serde",
@@ -4653,34 +4796,29 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.8.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4703,9 +4841,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4714,9 +4852,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4752,11 +4890,11 @@ version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit 0.22.23",
 ]
 
 [[package]]
@@ -4774,7 +4912,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4783,26 +4921,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
- "indexmap 2.4.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
-dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow 0.7.0",
 ]
 
 [[package]]
@@ -4813,9 +4940,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4824,20 +4951,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4856,9 +4983,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4874,12 +5001,11 @@ dependencies = [
 
 [[package]]
 name = "tree_magic_mini"
-version = "3.1.5"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469a727cac55b41448315cc10427c069c618ac59bb6a4480283fcd811749bdc2"
+checksum = "aac5e8971f245c3389a5a76e648bfc80803ae066a1243a75db0064d7c1129d63"
 dependencies = [
  "fnv",
- "home",
  "memchr",
  "nom",
  "once_cell",
@@ -4920,43 +5046,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4971,6 +5082,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4978,18 +5101,18 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
  "getrandom 0.2.15",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -5067,48 +5190,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.93"
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5116,22 +5249,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-logger"
@@ -5146,9 +5282,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -5173,9 +5309,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993"
+checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -5187,11 +5323,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.5"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943"
+checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -5203,7 +5339,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -5215,7 +5351,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5224,20 +5360,20 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.4"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b56f89937f1cf2ee1f1259cf2936a17a1f45d8f0aa1019fae6d470d304cfa6"
+checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.34.0",
+ "quick-xml 0.36.2",
  "quote",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.4"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148"
+checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
 dependencies = [
  "dlib",
  "log",
@@ -5246,9 +5382,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5471,7 +5607,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5482,7 +5618,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5566,11 +5702,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5581,11 +5733,11 @@ checksum = "f838de2fe15fe6bac988e74b798f26499a8b21a9d97edec321e79b28d1d7f597"
 
 [[package]]
 name = "windows-version"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6998aa457c9ba8ff2fb9f13e9d2a930dabcea28f1d0ab94d687d8b3654844515"
+checksum = "c12476c23a74725c539b24eae8bfc0dac4029c39cdb561d9f23616accd4ae26d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -5605,6 +5757,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5637,6 +5795,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5667,10 +5831,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5703,6 +5879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5733,6 +5915,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5749,6 +5937,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5781,6 +5975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5791,9 +5991,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
 dependencies = [
  "memchr",
 ]
@@ -5819,6 +6028,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
 name = "wl-clipboard-rs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5839,10 +6057,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "wry"
-version = "0.24.10"
+name = "write16"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00711278ed357350d44c749c286786ecac644e044e4da410d466212152383b45"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "wry"
+version = "0.24.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55c80b12287eb1ff7c365fc2f7a5037cb6181bd44c9fce81c8d1cf7605ffad6"
 dependencies = [
  "base64 0.13.1",
  "block",
@@ -5916,9 +6146,9 @@ checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xattr"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
 dependencies = [
  "libc",
  "linux-raw-sys",
@@ -6076,10 +6306,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "zbus"
-version = "4.4.0"
+name = "yoke"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2494e4b3f44d8363eef79a8a75fc0649efb710eef65a66b5e688a5eb4afe678a"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6094,19 +6348,17 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-sink",
  "futures-util",
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand 0.8.5",
  "serde",
  "serde_repr",
- "sha1",
  "static_assertions",
  "tracing",
  "uds_windows",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+ "winnow 0.6.26",
  "xdg-home",
  "zbus_macros",
  "zbus_names",
@@ -6115,25 +6367,28 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.4.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+checksum = "445efc01929302aee95e2b25bbb62a301ea8a6369466e4278e58e7d1dfb23631"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
+ "zbus_names",
+ "zvariant",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "3.0.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+checksum = "519629a3f80976d89c575895b05677cbc45eaf9f70d62a364d819ba646409cc8"
 dependencies = [
  "serde",
  "static_assertions",
+ "winnow 0.6.26",
  "zvariant",
 ]
 
@@ -6155,42 +6410,90 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "synstructure",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+checksum = "55e6b9b5f1361de2d5e7d9fd1ee5f6f7fcb6060618a1f82f3472f58f2b8d4be9"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "static_assertions",
+ "winnow 0.6.26",
  "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "4.2.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+checksum = "573a8dd76961957108b10f7a45bac6ab1ea3e9b7fe01aff88325dc57bb8f5c8b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "2.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+checksum = "ddd46446ea2a1f353bfda53e35f17633afa79f4fe290a611c94645c69fe96a50"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "serde",
+ "static_assertions",
+ "syn 2.0.96",
+ "winnow 0.6.26",
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735257413,
-        "narHash": "sha256-AJ/b5ucTcUIVnwLzl4eu5wsPXzA1eH2O0FO3F2UPPQk=",
+        "lastModified": 1738295101,
+        "narHash": "sha256-9RNbf+Mtb0Ku5Z/9vnCjQma4Gg2bQS1Jjs013P1nJV8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "162b4bf7b304b9a655ee01da216924946293f760",
+        "rev": "615530d5f11794d1dab9ea97509137c35217ec57",
         "type": "github"
       },
       "original": {

--- a/xdvdfs-cli/Cargo.toml
+++ b/xdvdfs-cli/Cargo.toml
@@ -20,7 +20,7 @@ futures = "0.3.28"
 anyhow = "1.0.71"
 env_logger = "0.10.0"
 maybe-async = "0.2.7"
-ciso = { version = "0.2.0", default-features = false }
+ciso = { version = "0.3.0", default-features = false }
 async-trait = "0.1.73"
 toml = { version = "0.8.19", features = ["preserve_order"] }
 serde = "1.0.209"

--- a/xdvdfs-cli/src/cmd_build_image.rs
+++ b/xdvdfs-cli/src/cmd_build_image.rs
@@ -208,8 +208,7 @@ pub async fn cmd_build_image(args: &BuildImageArgs) -> Result<(), anyhow::Error>
     };
 
     let stdfs = StdFilesystem::create(&source_path);
-    let mut remapfs: RemapOverlayFilesystem<std::io::Error, std::io::BufWriter<_>, _> =
-        RemapOverlayFilesystem::new(stdfs, overlay_cfg).await?;
+    let mut remapfs = RemapOverlayFilesystem::new(stdfs, overlay_cfg).await?;
 
     if args.dry_run {
         let mapped_entries = remapfs.dump();

--- a/xdvdfs-cli/src/cmd_compress.rs
+++ b/xdvdfs-cli/src/cmd_compress.rs
@@ -27,11 +27,8 @@ type BufFileSectorLinearFs<'a> = write::fs::SectorLinearBlockFilesystem<
     'a,
     write::fs::XDVDFSFilesystem<
         blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>>,
-        Box<[u8]>,
-        write::fs::DefaultCopier<
-            blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>>,
-            Box<[u8]>,
-        >,
+        [u8],
+        write::fs::DefaultCopier<blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>>, [u8]>,
     >,
 >;
 

--- a/xdvdfs-cli/src/cmd_compress.rs
+++ b/xdvdfs-cli/src/cmd_compress.rs
@@ -107,7 +107,8 @@ pub async fn cmd_compress(args: &CompressArgs) -> Result<(), anyhow::Error> {
     if is_dir {
         let mut fs = write::fs::StdFilesystem::create(&source_path);
         let mut slbd = write::fs::SectorLinearBlockDevice::default();
-        let mut slbfs: write::fs::SectorLinearBlockFilesystem<write::fs::StdFilesystem> = write::fs::SectorLinearBlockFilesystem::new(&mut fs);
+        let mut slbfs: write::fs::SectorLinearBlockFilesystem<write::fs::StdFilesystem> =
+            write::fs::SectorLinearBlockFilesystem::new(&mut fs);
 
         write::img::create_xdvdfs_image(&mut slbfs, &mut slbd, progress_callback).await?;
 

--- a/xdvdfs-cli/src/cmd_info.rs
+++ b/xdvdfs-cli/src/cmd_info.rs
@@ -71,7 +71,7 @@ fn print_dirent(dirent: &DirectoryEntryNode) -> Result<(), anyhow::Error> {
 #[maybe_async]
 async fn print_subdir(
     subdir: &DirectoryEntryTable,
-    img: &mut impl BlockDeviceRead<std::io::Error>,
+    img: &mut impl BlockDeviceRead<ReadError = std::io::Error>,
 ) -> Result<(), anyhow::Error> {
     let children = subdir.walk_dirent_tree(img).await?;
     for node in children {

--- a/xdvdfs-cli/src/cmd_md5.rs
+++ b/xdvdfs-cli/src/cmd_md5.rs
@@ -17,7 +17,7 @@ pub struct Md5Args {
 
 #[maybe_async]
 async fn md5_file_dirent<E>(
-    img: &mut impl xdvdfs::blockdev::BlockDeviceRead<E>,
+    img: &mut impl xdvdfs::blockdev::BlockDeviceRead<ReadError = E>,
     file: xdvdfs::layout::DirectoryEntryNode,
 ) -> Result<String, util::Error<E>> {
     let file_buf = file.node.dirent.read_data_all(img).await?;
@@ -31,7 +31,7 @@ async fn md5_file_dirent<E>(
 
 #[maybe_async]
 async fn md5_file_tree<E>(
-    img: &mut impl xdvdfs::blockdev::BlockDeviceRead<E>,
+    img: &mut impl xdvdfs::blockdev::BlockDeviceRead<ReadError = E>,
     tree: &Vec<(String, xdvdfs::layout::DirectoryEntryNode)>,
     base: &str,
 ) -> Result<(), util::Error<E>> {
@@ -54,7 +54,7 @@ async fn md5_file_tree<E>(
 #[maybe_async]
 async fn md5_from_file_path<E>(
     volume: &xdvdfs::layout::VolumeDescriptor,
-    img: &mut impl xdvdfs::blockdev::BlockDeviceRead<E>,
+    img: &mut impl xdvdfs::blockdev::BlockDeviceRead<ReadError = E>,
     file: &str,
 ) -> Result<(), util::Error<E>> {
     let dirent = volume.root_table.walk_path(img, file).await?;
@@ -72,7 +72,7 @@ async fn md5_from_file_path<E>(
 #[maybe_async]
 async fn md5_from_root_tree<E>(
     volume: &xdvdfs::layout::VolumeDescriptor,
-    img: &mut impl xdvdfs::blockdev::BlockDeviceRead<E>,
+    img: &mut impl xdvdfs::blockdev::BlockDeviceRead<ReadError = E>,
 ) -> Result<(), util::Error<E>> {
     let tree = volume.root_table.file_tree(img).await?;
     md5_file_tree(img, &tree, "").await

--- a/xdvdfs-cli/src/cmd_pack.rs
+++ b/xdvdfs-cli/src/cmd_pack.rs
@@ -86,7 +86,7 @@ pub async fn cmd_pack(args: &PackArgs) -> Result<(), anyhow::Error> {
     } else if meta.is_file() {
         let source = crate::img::open_image_raw(&source_path).await?;
         let mut fs =
-            write::fs::XDVDFSFilesystem::<_, _, _, write::fs::StdIOCopier<_, _, _>>::new(source)
+            write::fs::XDVDFSFilesystem::<_, _, write::fs::StdIOCopier<_, _>>::new(source)
                 .await
                 .ok_or(anyhow::anyhow!("Failed to create XDVDFS filesystem"))?;
         write::img::create_xdvdfs_image(&mut fs, &mut image, progress_callback).await?;

--- a/xdvdfs-cli/src/cmd_pack.rs
+++ b/xdvdfs-cli/src/cmd_pack.rs
@@ -85,10 +85,9 @@ pub async fn cmd_pack(args: &PackArgs) -> Result<(), anyhow::Error> {
         write::img::create_xdvdfs_image(&mut fs, &mut image, progress_callback).await?;
     } else if meta.is_file() {
         let source = crate::img::open_image_raw(&source_path).await?;
-        let mut fs =
-            write::fs::XDVDFSFilesystem::<_, _, write::fs::StdIOCopier<_, _>>::new(source)
-                .await
-                .ok_or(anyhow::anyhow!("Failed to create XDVDFS filesystem"))?;
+        let mut fs = write::fs::XDVDFSFilesystem::<_, _, write::fs::StdIOCopier<_, _>>::new(source)
+            .await
+            .ok_or(anyhow::anyhow!("Failed to create XDVDFS filesystem"))?;
         write::img::create_xdvdfs_image(&mut fs, &mut image, progress_callback).await?;
     } else {
         return Err(anyhow::anyhow!("Symlink image sources are not supported"));

--- a/xdvdfs-cli/src/cmd_unpack.rs
+++ b/xdvdfs-cli/src/cmd_unpack.rs
@@ -11,7 +11,7 @@ use xdvdfs::{blockdev::OffsetWrapper, layout::DirectoryEntryTable};
 
 #[maybe_async]
 async fn copyout_directory(
-    img: &mut OffsetWrapper<BufReader<File>, std::io::Error>,
+    img: &mut OffsetWrapper<BufReader<File>>,
     dest_dir: &Path,
     dirtab: &DirectoryEntryTable,
 ) -> Result<(), anyhow::Error> {

--- a/xdvdfs-cli/src/img.rs
+++ b/xdvdfs-cli/src/img.rs
@@ -7,15 +7,17 @@ use std::{
 };
 use xdvdfs::blockdev::{BlockDeviceRead, OffsetWrapper};
 
-pub struct CSOBlockDevice<R: ciso::read::Read<std::io::Error>> {
+pub struct CSOBlockDevice<R: ciso::read::Read<ReadError = std::io::Error>> {
     inner: CSOReader<std::io::Error, R>,
 }
 
 #[maybe_async]
-impl<R> BlockDeviceRead<std::io::Error> for CSOBlockDevice<R>
+impl<R> BlockDeviceRead for CSOBlockDevice<R>
 where
-    R: ciso::read::Read<std::io::Error>,
+    R: ciso::read::Read<ReadError = std::io::Error>,
 {
+    type ReadError = std::io::Error;
+
     async fn read(&mut self, offset: u64, buffer: &mut [u8]) -> Result<(), std::io::Error> {
         self.inner
             .read_offset(offset, buffer)
@@ -30,7 +32,7 @@ where
 #[maybe_async]
 pub async fn open_image_raw(
     path: &Path,
-) -> Result<OffsetWrapper<BufReader<File>, std::io::Error>, anyhow::Error> {
+) -> Result<OffsetWrapper<BufReader<File>>, anyhow::Error> {
     let img = File::options().read(true).open(path)?;
     let img = std::io::BufReader::new(img);
     Ok(xdvdfs::blockdev::OffsetWrapper::new(img).await?)
@@ -39,12 +41,12 @@ pub async fn open_image_raw(
 #[maybe_async]
 pub async fn open_image(
     path: &Path,
-) -> Result<Box<dyn BlockDeviceRead<std::io::Error>>, anyhow::Error> {
+) -> Result<Box<dyn BlockDeviceRead<ReadError = std::io::Error>>, anyhow::Error> {
     if path.extension().is_some_and(|e| e == "cso") {
         let file_base = path.with_extension("");
         let split = file_base.extension().is_some_and(|e| e == "1");
 
-        let reader: Box<dyn ciso::read::Read<std::io::Error>> = if split {
+        let reader: Box<dyn ciso::read::Read<ReadError = std::io::Error>> = if split {
             let mut files = Vec::new();
             for i in 1.. {
                 let part = file_base.with_extension(format!("{}.cso", i));

--- a/xdvdfs-cli/src/img.rs
+++ b/xdvdfs-cli/src/img.rs
@@ -30,9 +30,7 @@ where
 }
 
 #[maybe_async]
-pub async fn open_image_raw(
-    path: &Path,
-) -> Result<OffsetWrapper<BufReader<File>>, anyhow::Error> {
+pub async fn open_image_raw(path: &Path) -> Result<OffsetWrapper<BufReader<File>>, anyhow::Error> {
     let img = File::options().read(true).open(path)?;
     let img = std::io::BufReader::new(img);
     Ok(xdvdfs::blockdev::OffsetWrapper::new(img).await?)

--- a/xdvdfs-core/Cargo.toml
+++ b/xdvdfs-core/Cargo.toml
@@ -25,7 +25,7 @@ maybe-async = "0.2.7"
 arrayvec = { version = "0.7.2", default-features = false, optional = true}
 log = { version = "0.4.17", optional = true }
 sha3 = { version = "0.10.8", optional = true, default-features = false }
-ciso = { version = "0.2.0", default-features = false, optional = true }
+ciso = { version = "0.3.0", default-features = false, optional = true }
 wax = { version = "0.6.0", default-features = false, optional = true }
 
 [features]

--- a/xdvdfs-core/src/blockdev.rs
+++ b/xdvdfs-core/src/blockdev.rs
@@ -152,7 +152,9 @@ where
     T: BlockDeviceRead + Sized,
 {
     #[maybe_async]
-    pub async fn new(dev: T) -> Result<Self, crate::util::Error<<T as BlockDeviceRead>::ReadError>> {
+    pub async fn new(
+        dev: T,
+    ) -> Result<Self, crate::util::Error<<T as BlockDeviceRead>::ReadError>> {
         let mut s = Self {
             inner: dev,
             offset: 0,

--- a/xdvdfs-core/src/blockdev.rs
+++ b/xdvdfs-core/src/blockdev.rs
@@ -41,9 +41,6 @@ pub trait BlockDeviceWrite: Send + Sync {
     }
 }
 
-// Impl for [u8] only if the std::io::Read blanket impls are not present,
-// as they otherwise cover the type
-
 #[derive(Copy, Clone, Debug)]
 pub struct OutOfBounds;
 

--- a/xdvdfs-core/src/checksum.rs
+++ b/xdvdfs-core/src/checksum.rs
@@ -9,10 +9,10 @@ use crate::{
 use maybe_async::maybe_async;
 
 #[maybe_async]
-pub async fn checksum<E>(
-    dev: &mut impl BlockDeviceRead<E>,
+pub async fn checksum<BDR: BlockDeviceRead>(
+    dev: &mut BDR,
     volume: &VolumeDescriptor,
-) -> Result<[u8; 32], util::Error<E>> {
+) -> Result<[u8; 32], util::Error<BDR::ReadError>> {
     let mut hasher = Sha3_256::new();
 
     let tree = volume.root_table.file_tree(dev).await?;

--- a/xdvdfs-core/src/layout.rs
+++ b/xdvdfs-core/src/layout.rs
@@ -319,7 +319,8 @@ impl DirectoryEntryData {
         if bytes_read != self.name.len() {
             Err(FileStructureError::StringEncodingError)
         } else {
-            TryInto::<u8>::try_into(bytes_written).map_err(|_| FileStructureError::StringEncodingError)
+            TryInto::<u8>::try_into(bytes_written)
+                .map_err(|_| FileStructureError::StringEncodingError)
         }
     }
 

--- a/xdvdfs-core/src/layout.rs
+++ b/xdvdfs-core/src/layout.rs
@@ -242,7 +242,7 @@ impl DirectoryEntryDiskData {
         let offset = self.data.offset(0)?;
         dev.read(offset, buf)
             .await
-            .map_err(|e| util::Error::IOError(e))?;
+            .map_err(util::Error::IOError)?;
         Ok(())
     }
 
@@ -262,7 +262,7 @@ impl DirectoryEntryDiskData {
         let offset = self.data.offset(0)?;
         dev.read(offset, &mut buf)
             .await
-            .map_err(|e| util::Error::IOError(e))?;
+            .map_err(util::Error::IOError)?;
 
         Ok(buf)
     }

--- a/xdvdfs-core/src/layout.rs
+++ b/xdvdfs-core/src/layout.rs
@@ -240,9 +240,7 @@ impl DirectoryEntryDiskData {
         }
 
         let offset = self.data.offset(0)?;
-        dev.read(offset, buf)
-            .await
-            .map_err(util::Error::IOError)?;
+        dev.read(offset, buf).await.map_err(util::Error::IOError)?;
         Ok(())
     }
 

--- a/xdvdfs-core/src/layout.rs
+++ b/xdvdfs-core/src/layout.rs
@@ -230,7 +230,7 @@ impl DirectoryEntryDiskData {
 
     #[cfg(feature = "read")]
     #[maybe_async]
-    pub async fn read_data<BDR: crate::blockdev::BlockDeviceRead>(
+    pub async fn read_data<BDR: crate::blockdev::BlockDeviceRead + ?Sized>(
         &self,
         dev: &mut BDR,
         buf: &mut [u8],
@@ -246,7 +246,7 @@ impl DirectoryEntryDiskData {
 
     #[cfg(feature = "read")]
     #[maybe_async]
-    pub async fn read_data_all<BDR: crate::blockdev::BlockDeviceRead>(
+    pub async fn read_data_all<BDR: crate::blockdev::BlockDeviceRead + ?Sized>(
         &self,
         dev: &mut BDR,
     ) -> Result<alloc::boxed::Box<[u8]>, util::Error<BDR::ReadError>> {
@@ -382,7 +382,7 @@ mod test {
         };
 
         let mut buf = [0; 8];
-        executor::block_on(dirent.read_data(&mut data, &mut buf)).unwrap();
+        executor::block_on(dirent.read_data(data.as_mut_slice(), &mut buf)).unwrap();
     }
 
     #[test]
@@ -395,7 +395,7 @@ mod test {
             filename_length: 0,
         };
 
-        let data = executor::block_on(dirent.read_data_all(&mut data)).unwrap();
+        let data = executor::block_on(dirent.read_data_all(data.as_mut_slice())).unwrap();
         assert_eq!(data.len(), 0);
     }
 }

--- a/xdvdfs-core/src/layout.rs
+++ b/xdvdfs-core/src/layout.rs
@@ -162,20 +162,18 @@ impl VolumeDescriptor {
         self.magic0 == VOLUME_HEADER_MAGIC && self.magic1 == VOLUME_HEADER_MAGIC
     }
 
-    pub fn serialize<E>(&self) -> Result<alloc::vec::Vec<u8>, util::Error<E>> {
+    pub fn serialize(&self) -> Result<alloc::vec::Vec<u8>, bincode::Error> {
         bincode::DefaultOptions::new()
             .with_fixint_encoding()
             .with_little_endian()
             .serialize(self)
-            .map_err(|e| util::Error::SerializationFailed(e))
     }
 
-    pub fn deserialize<E>(buf: &[u8; 0x800]) -> Result<Self, util::Error<E>> {
+    pub fn deserialize(buf: &[u8; 0x800]) -> Result<Self, bincode::Error> {
         bincode::DefaultOptions::new()
             .with_fixint_encoding()
             .with_little_endian()
             .deserialize(buf)
-            .map_err(|e| util::Error::SerializationFailed(e))
     }
 }
 
@@ -232,11 +230,11 @@ impl DirectoryEntryDiskData {
 
     #[cfg(feature = "read")]
     #[maybe_async]
-    pub async fn read_data<E>(
+    pub async fn read_data<BDR: crate::blockdev::BlockDeviceRead>(
         &self,
-        dev: &mut impl super::blockdev::BlockDeviceRead<E>,
+        dev: &mut BDR,
         buf: &mut [u8],
-    ) -> Result<(), util::Error<E>> {
+    ) -> Result<(), util::Error<BDR::ReadError>> {
         if self.data.size == 0 {
             return Ok(());
         }
@@ -250,10 +248,10 @@ impl DirectoryEntryDiskData {
 
     #[cfg(feature = "read")]
     #[maybe_async]
-    pub async fn read_data_all<E>(
+    pub async fn read_data_all<BDR: crate::blockdev::BlockDeviceRead>(
         &self,
-        dev: &mut impl super::blockdev::BlockDeviceRead<E>,
-    ) -> Result<alloc::boxed::Box<[u8]>, util::Error<E>> {
+        dev: &mut BDR,
+    ) -> Result<alloc::boxed::Box<[u8]>, util::Error<BDR::ReadError>> {
         let buf = alloc::vec![0; self.data.size as usize];
         let mut buf = buf.into_boxed_slice();
 
@@ -309,24 +307,25 @@ impl DirectoryEntryData {
         self.name.as_str()
     }
 
-    pub fn encode_name<E>(&self, buffer: &mut [u8]) -> Result<u8, util::Error<E>> {
+    pub fn encode_name(&self, buffer: &mut [u8]) -> Result<u8, crate::write::FileStructureError> {
+        use crate::write::FileStructureError;
         let mut encoder = WINDOWS_1252.new_encoder();
         let (result, bytes_read, bytes_written) =
             encoder.encode_from_utf8_without_replacement(self.name_str(), buffer, true);
         match result {
             encoding_rs::EncoderResult::InputEmpty => {}
-            _ => return Err(util::Error::StringEncodingError),
+            _ => return Err(FileStructureError::StringEncodingError),
         }
         if bytes_read != self.name.len() {
-            Err(util::Error::StringEncodingError)
+            Err(FileStructureError::StringEncodingError)
         } else {
-            TryInto::<u8>::try_into(bytes_written).map_err(|_| util::Error::StringEncodingError)
+            TryInto::<u8>::try_into(bytes_written).map_err(|_| FileStructureError::StringEncodingError)
         }
     }
 
     /// Returns the length (in bytes) of the directory entry
     /// on disk, after serialization
-    pub fn len_on_disk<E>(&self) -> Result<u32, util::Error<E>> {
+    pub fn len_on_disk(&self) -> Result<u32, crate::write::FileStructureError> {
         let encoded_filename_len = self.encode_name(&mut [0; 256])?;
         let mut size = 0xe + (encoded_filename_len as u32);
 
@@ -353,20 +352,18 @@ impl Ord for DirectoryEntryData {
 }
 
 impl DirectoryEntryDiskNode {
-    pub fn serialize<E>(&self) -> Result<alloc::vec::Vec<u8>, util::Error<E>> {
+    pub fn serialize(&self) -> Result<alloc::vec::Vec<u8>, bincode::Error> {
         bincode::DefaultOptions::new()
             .with_fixint_encoding()
             .with_little_endian()
             .serialize(self)
-            .map_err(|e| util::Error::SerializationFailed(e))
     }
 
-    pub fn deserialize<E>(buf: &[u8; 0xe]) -> Result<Self, util::Error<E>> {
+    pub fn deserialize(buf: &[u8; 0xe]) -> Result<Self, bincode::Error> {
         bincode::DefaultOptions::new()
             .with_fixint_encoding()
             .with_little_endian()
             .deserialize(buf)
-            .map_err(|e| util::Error::SerializationFailed(e))
     }
 }
 

--- a/xdvdfs-core/src/read.rs
+++ b/xdvdfs-core/src/read.rs
@@ -100,7 +100,7 @@ pub async fn read_volume<BDR: BlockDeviceRead>(
         .map_err(|_| util::Error::InvalidVolume)?;
 
     let volume =
-        VolumeDescriptor::deserialize(&buffer).map_err(|e| util::Error::SerializationFailed(e))?;
+        VolumeDescriptor::deserialize(&buffer).map_err(util::Error::SerializationFailed)?;
     if volume.is_valid() {
         Ok(volume)
     } else {
@@ -137,7 +137,7 @@ async fn read_dirent<BDR: BlockDeviceRead>(
     let mut dirent_buf = [0; 0xe];
     dev.read(offset, &mut dirent_buf)
         .await
-        .map_err(|e| util::Error::IOError(e))?;
+        .map_err(util::Error::IOError)?;
 
     let dirent = deserialize_dirent_node(&dirent_buf, offset)?;
     if let Some(mut dirent) = dirent {
@@ -145,7 +145,7 @@ async fn read_dirent<BDR: BlockDeviceRead>(
         let name_buf = &mut dirent.name[0..name_len];
         dev.read(offset + 0xe, name_buf)
             .await
-            .map_err(|e| util::Error::IOError(e))?;
+            .map_err(util::Error::IOError)?;
 
         Ok(Some(dirent))
     } else {

--- a/xdvdfs-core/src/read.rs
+++ b/xdvdfs-core/src/read.rs
@@ -35,7 +35,9 @@ impl<BDR: BlockDeviceRead> DirentScanIter<'_, BDR> {
     }
 
     #[maybe_async]
-    pub async fn next_entry(&mut self) -> Result<Option<DirectoryEntryNode>, util::Error<BDR::ReadError>> {
+    pub async fn next_entry(
+        &mut self,
+    ) -> Result<Option<DirectoryEntryNode>, util::Error<BDR::ReadError>> {
         if self.sector >= self.end_sector {
             return Ok(None);
         }
@@ -97,8 +99,8 @@ pub async fn read_volume<BDR: BlockDeviceRead>(
         .await
         .map_err(|_| util::Error::InvalidVolume)?;
 
-    let volume = VolumeDescriptor::deserialize(&buffer)
-        .map_err(|e| util::Error::SerializationFailed(e))?;
+    let volume =
+        VolumeDescriptor::deserialize(&buffer).map_err(|e| util::Error::SerializationFailed(e))?;
     if volume.is_valid() {
         Ok(volume)
     } else {
@@ -323,7 +325,10 @@ impl DirectoryEntryTable {
     pub async fn file_tree<BDR: BlockDeviceRead>(
         &self,
         dev: &mut BDR,
-    ) -> Result<alloc::vec::Vec<(alloc::string::String, DirectoryEntryNode)>, util::Error<BDR::ReadError>> {
+    ) -> Result<
+        alloc::vec::Vec<(alloc::string::String, DirectoryEntryNode)>,
+        util::Error<BDR::ReadError>,
+    > {
         use alloc::format;
         use alloc::string::String;
         use alloc::vec;

--- a/xdvdfs-core/src/read.rs
+++ b/xdvdfs-core/src/read.rs
@@ -80,7 +80,7 @@ impl<BDR: BlockDeviceRead> DirentScanIter<'_, BDR> {
 }
 
 #[cfg(feature = "sync")]
-impl<BDR: BlockDeviceRead<E>> Iterator for DirentScanIter<'_, BDR> {
+impl<E, BDR: BlockDeviceRead<ReadError = E>> Iterator for DirentScanIter<'_, BDR> {
     type Item = DirectoryEntryNode;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/xdvdfs-core/src/write/dirtab.rs
+++ b/xdvdfs-core/src/write/dirtab.rs
@@ -201,7 +201,7 @@ impl DirectoryEntryTableWriter {
 
             let bytes = dirent
                 .serialize()
-                .map_err(|e| FileStructureError::SerializationError(e))?;
+                .map_err(FileStructureError::SerializationError)?;
             let size = bytes.len() + dirent.dirent.filename_length as usize;
             assert_eq!(bytes.len(), 0xe);
 

--- a/xdvdfs-core/src/write/dirtab.rs
+++ b/xdvdfs-core/src/write/dirtab.rs
@@ -47,7 +47,8 @@ impl DirectoryEntryTableWriter {
         size: u32,
         attributes: DirentAttributes,
     ) -> Result<(), FileStructureError> {
-        let name = arrayvec::ArrayString::from(name).map_err(|_| FileStructureError::FileNameTooLong)?;
+        let name =
+            arrayvec::ArrayString::from(name).map_err(|_| FileStructureError::FileNameTooLong)?;
         let filename_length = name
             .len()
             .try_into()
@@ -198,7 +199,8 @@ impl DirectoryEntryTableWriter {
                 is_dir: dirent.dirent.attributes.directory(),
             });
 
-            let bytes = dirent.serialize()
+            let bytes = dirent
+                .serialize()
                 .map_err(|e| FileStructureError::SerializationError(e))?;
             let size = bytes.len() + dirent.dirent.filename_length as usize;
             assert_eq!(bytes.len(), 0xe);

--- a/xdvdfs-core/src/write/dirtab.rs
+++ b/xdvdfs-core/src/write/dirtab.rs
@@ -2,13 +2,13 @@ use crate::layout::{
     self, DirectoryEntryData, DirectoryEntryDiskData, DirectoryEntryDiskNode, DirentAttributes,
     DiskRegion,
 };
-use crate::util;
 use crate::write::avl;
 
 use alloc::string::ToString;
 use alloc::{boxed::Box, string::String, vec::Vec};
 
 use super::sector::{required_sectors, SectorAllocator};
+use super::FileStructureError;
 
 /// Writer for directory entry tables
 #[derive(Default)]
@@ -41,17 +41,17 @@ fn sector_align(offset: u64, incr: u64) -> u32 {
 }
 
 impl DirectoryEntryTableWriter {
-    fn add_node<E>(
+    fn add_node(
         &mut self,
         name: &str,
         size: u32,
         attributes: DirentAttributes,
-    ) -> Result<(), util::Error<E>> {
-        let name = arrayvec::ArrayString::from(name).map_err(|_| util::Error::NameTooLong)?;
+    ) -> Result<(), FileStructureError> {
+        let name = arrayvec::ArrayString::from(name).map_err(|_| FileStructureError::FileNameTooLong)?;
         let filename_length = name
             .len()
             .try_into()
-            .map_err(|_| util::Error::NameTooLong)?;
+            .map_err(|_| FileStructureError::FileNameTooLong)?;
 
         let dirent = DirectoryEntryData {
             node: DirectoryEntryDiskData {
@@ -66,27 +66,27 @@ impl DirectoryEntryTableWriter {
         self.table
             .insert(dirent)
             .then_some(())
-            .ok_or(util::Error::InvalidFileName)
+            .ok_or(FileStructureError::DuplicateFileName)
     }
 
-    pub fn add_dir<E>(&mut self, name: &str, size: u32) -> Result<(), util::Error<E>> {
+    pub fn add_dir(&mut self, name: &str, size: u32) -> Result<(), FileStructureError> {
         let attributes = DirentAttributes(0).with_directory(true);
 
         let size = size + ((2048 - size % 2048) % 2048);
         self.add_node(name, size, attributes)
     }
 
-    pub fn add_file<E>(&mut self, name: &str, size: u32) -> Result<(), util::Error<E>> {
+    pub fn add_file(&mut self, name: &str, size: u32) -> Result<(), FileStructureError> {
         let attributes = DirentAttributes(0).with_archive(true);
         self.add_node(name, size, attributes)
     }
 
-    pub fn compute_size<E>(&mut self) -> Result<(), util::Error<E>> {
+    pub fn compute_size(&mut self) -> Result<(), FileStructureError> {
         self.size = Some(
             self.table
                 .preorder_iter()
                 .map(|node| node.len_on_disk())
-                .try_fold(0, |acc: u32, disk_len: Result<u32, util::Error<E>>| {
+                .try_fold(0, |acc: u32, disk_len: Result<u32, FileStructureError>| {
                     disk_len
                         .map(|disk_len| acc + disk_len + sector_align(acc as u64, disk_len as u64))
                 })?,
@@ -116,10 +116,10 @@ impl DirectoryEntryTableWriter {
     ///
     /// Returns a byte slice representing the on-disk directory entry table,
     /// and a mapping of files to allocated sectors
-    pub fn disk_repr<E>(
+    pub fn disk_repr(
         mut self,
         allocator: &mut SectorAllocator,
-    ) -> Result<DirectoryEntryTableDiskRepr, util::Error<E>> {
+    ) -> Result<DirectoryEntryTableDiskRepr, FileStructureError> {
         if self.table.backing_vec().is_empty() {
             return Ok(DirectoryEntryTableDiskRepr {
                 entry_table: alloc::vec![0xff; 2048].into_boxed_slice(),
@@ -131,7 +131,7 @@ impl DirectoryEntryTableWriter {
 
         // Array of offsets for each entry in the table
         // The offset is a partial sum of lengths of the dirent on disk
-        let offsets: Result<Vec<u64>, util::Error<E>> = self
+        let offsets: Result<Vec<u64>, FileStructureError> = self
             .table
             .backing_vec()
             .iter()
@@ -175,13 +175,13 @@ impl DirectoryEntryTableWriter {
                 .map(|idx| offsets[idx] / 4)
                 .unwrap_or_default()
                 .try_into()
-                .map_err(|_| util::Error::TooManyDirectoryEntries)?;
+                .map_err(|_| FileStructureError::TooManyDirectoryEntries)?;
             let right_entry_offset: u16 = node
                 .right_idx()
                 .map(|idx| offsets[idx] / 4)
                 .unwrap_or_default()
                 .try_into()
-                .map_err(|_| util::Error::TooManyDirectoryEntries)?;
+                .map_err(|_| FileStructureError::TooManyDirectoryEntries)?;
             let mut dirent = DirectoryEntryDiskNode {
                 left_entry_offset,
                 right_entry_offset,
@@ -198,7 +198,8 @@ impl DirectoryEntryTableWriter {
                 is_dir: dirent.dirent.attributes.directory(),
             });
 
-            let bytes = dirent.serialize()?;
+            let bytes = dirent.serialize()
+                .map_err(|e| FileStructureError::SerializationError(e))?;
             let size = bytes.len() + dirent.dirent.filename_length as usize;
             assert_eq!(bytes.len(), 0xe);
 

--- a/xdvdfs-core/src/write/fs/mod.rs
+++ b/xdvdfs-core/src/write/fs/mod.rs
@@ -115,8 +115,76 @@ impl<'a> FromIterator<&'a str> for PathVec {
     }
 }
 
+/// A trait for filesystem hierarchies, representing any filesystem
+/// structure with hierarchical directories.
+///
+/// This trait allows for scanning a given directory within a filesystem
+/// for a list of its entries and entry metadata.
 #[maybe_async]
-pub trait Filesystem<RawHandle: BlockDeviceWrite<RHError>, E, RHError: Into<E> = E>:
+pub trait FilesystemHierarchy: Send + Sync {
+    type Error;
+
+    /// Read a directory, and return a list of entries within it
+    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, Self::Error>;
+
+    /// Display a filesystem path as a String
+    fn path_to_string(&self, path: &PathVec) -> String {
+        path.as_string()
+    }
+}
+
+#[maybe_async]
+impl<E> FilesystemHierarchy for Box<dyn FilesystemHierarchy<Error = E>> {
+    type Error = E;
+
+    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, E> {
+        self.as_mut().read_dir(path).await
+    }
+
+    fn path_to_string(&self, path: &PathVec) -> String {
+        self.as_ref().path_to_string(path)
+    }
+}
+
+/// A trait for copying data out of a filesystem.
+///
+/// Allows for copying data from a specified filesystem path
+/// into an output block device, specialized by the block device type.
+/// Multiple implementations of this trait allow the filesystem to be
+/// used to create images on various output types.
+#[maybe_async]
+pub trait FilesystemCopier<BDW: BlockDeviceWrite + ?Sized>: Send + Sync {
+    type Error;
+
+    /// Copy the entire contents of file `src` into `dest` at the specified offset
+    async fn copy_file_in(
+        &mut self,
+        src: &PathVec,
+        dest: &mut BDW,
+        offset: u64,
+        size: u64,
+    ) -> Result<u64, Self::Error>;
+}
+
+#[maybe_async]
+impl<E, BDW: BlockDeviceWrite> FilesystemCopier<BDW> for Box<dyn FilesystemCopier<BDW, Error = E>> {
+    type Error = E;
+
+    async fn copy_file_in(
+        &mut self,
+        src: &PathVec,
+        dest: &mut BDW,
+        offset: u64,
+        size: u64,
+    ) -> Result<u64, E> {
+        self.as_mut().copy_file_in(src, dest, offset, size).await
+    }
+}
+
+/// Legacy Filesystem trait. Use FilesystemHierarchy and FilesystemCopier instead.
+#[maybe_async]
+#[deprecated]
+pub trait Filesystem<RawHandle: BlockDeviceWrite<WriteError = RHError>, E, RHError: Into<E> = E>:
     Send + Sync
 {
     /// Read a directory, and return a list of entries within it
@@ -146,8 +214,11 @@ pub trait Filesystem<RawHandle: BlockDeviceWrite<RHError>, E, RHError: Into<E> =
     }
 }
 
+// Deprecated: Filesystem<R, E> will be removed
+// Kept for legacy implementations
 #[maybe_async]
-impl<E: Send + Sync, R: BlockDeviceWrite<E>> Filesystem<R, E> for Box<dyn Filesystem<R, E>> {
+#[allow(deprecated)]
+impl<E: Send + Sync, R: BlockDeviceWrite<WriteError = E>> Filesystem<R, E> for Box<dyn Filesystem<R, E>> {
     async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, E> {
         self.as_mut().read_dir(path).await
     }

--- a/xdvdfs-core/src/write/fs/mod.rs
+++ b/xdvdfs-core/src/write/fs/mod.rs
@@ -218,7 +218,9 @@ pub trait Filesystem<RawHandle: BlockDeviceWrite<WriteError = RHError>, E, RHErr
 // Kept for legacy implementations
 #[maybe_async]
 #[allow(deprecated)]
-impl<E: Send + Sync, R: BlockDeviceWrite<WriteError = E>> Filesystem<R, E> for Box<dyn Filesystem<R, E>> {
+impl<E: Send + Sync, R: BlockDeviceWrite<WriteError = E>> Filesystem<R, E>
+    for Box<dyn Filesystem<R, E>>
+{
     async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, E> {
         self.as_mut().read_dir(path).await
     }

--- a/xdvdfs-core/src/write/fs/remap.rs
+++ b/xdvdfs-core/src/write/fs/remap.rs
@@ -351,7 +351,8 @@ where
         &mut self,
         src: &PathVec,
         dest: &mut BDW,
-        offset: u64,
+        input_offset: u64,
+        output_offset: u64,
         size: u64,
     ) -> Result<u64, RemapOverlayError<E>> {
         let entry = self
@@ -359,7 +360,7 @@ where
             .get(src)
             .ok_or_else(|| RemapOverlayError::NoSuchFile(src.as_string()))?;
         self.fs
-            .copy_file_in(&entry.host_path, dest, offset, size)
+            .copy_file_in(&entry.host_path, dest, input_offset, output_offset, size)
             .await
             .map_err(|e| e.into())
     }

--- a/xdvdfs-core/src/write/fs/remap.rs
+++ b/xdvdfs-core/src/write/fs/remap.rs
@@ -281,10 +281,7 @@ where
             }
         }
 
-        Ok(Self {
-            img_to_host,
-            fs,
-        })
+        Ok(Self { img_to_host, fs })
     }
 
     pub fn dump(&self) -> Vec<(PathVec, PathVec)> {
@@ -315,12 +312,15 @@ where
 
 #[maybe_async]
 impl<F> FilesystemHierarchy for RemapOverlayFilesystem<F>
-where 
+where
     F: FilesystemHierarchy,
 {
     type Error = RemapOverlayError<F::Error>;
 
-    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, RemapOverlayError<F::Error>> {
+    async fn read_dir(
+        &mut self,
+        path: &PathVec,
+    ) -> Result<Vec<FileEntry>, RemapOverlayError<F::Error>> {
         let dir = self
             .img_to_host
             .lookup_subdir(path)
@@ -336,12 +336,10 @@ where
 
         Ok(entries)
     }
-
 }
 
 #[maybe_async]
-impl<BDW, E, FS> FilesystemCopier<BDW>
-    for RemapOverlayFilesystem<FS>
+impl<BDW, E, FS> FilesystemCopier<BDW> for RemapOverlayFilesystem<FS>
 where
     E: Into<RemapOverlayError<E>> + Send + Sync,
     BDW: BlockDeviceWrite,

--- a/xdvdfs-core/src/write/fs/remap.rs
+++ b/xdvdfs-core/src/write/fs/remap.rs
@@ -10,7 +10,7 @@ use alloc::boxed::Box;
 
 use crate::blockdev::BlockDeviceWrite;
 
-use super::{FileEntry, FileType, Filesystem, PathPrefixTree, PathVec};
+use super::{FileEntry, FileType, FilesystemCopier, FilesystemHierarchy, PathPrefixTree, PathVec};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct RemapOverlayConfig {
@@ -95,24 +95,19 @@ impl<E: Display> Display for RemapOverlayError<E> {
 impl<E: Display + core::fmt::Debug> std::error::Error for RemapOverlayError<E> {}
 
 #[derive(Clone, Debug)]
-pub struct RemapOverlayFilesystem<BDE, BD: BlockDeviceWrite<BDE>, FS: Filesystem<BD, BDE>> {
+pub struct RemapOverlayFilesystem<FS> {
     img_to_host: PathPrefixTree<MapEntry>,
     fs: FS,
-
-    bde_type: core::marker::PhantomData<BDE>,
-    bd_type: core::marker::PhantomData<BD>,
-    fs_type: core::marker::PhantomData<FS>,
 }
 
-impl<BDE, BD, FS> RemapOverlayFilesystem<BDE, BD, FS>
+impl<E, FS> RemapOverlayFilesystem<FS>
 where
-    BDE: Into<RemapOverlayError<BDE>> + Send + Sync,
-    BD: BlockDeviceWrite<BDE>,
-    FS: Filesystem<BD, BDE>,
+    E: Into<RemapOverlayError<E>> + Send + Sync,
+    FS: FilesystemHierarchy<Error = E>,
 {
     fn find_match_indices(
         rewrite: &str,
-    ) -> Result<Vec<usize>, RemapOverlayFilesystemBuildingError<BDE>> {
+    ) -> Result<Vec<usize>, RemapOverlayFilesystemBuildingError<E>> {
         let mut match_indices: Vec<usize> = Vec::new();
         let mut match_index = 0;
         let mut matching = false;
@@ -167,7 +162,7 @@ where
     pub async fn new(
         mut fs: FS,
         cfg: RemapOverlayConfig,
-    ) -> Result<Self, RemapOverlayFilesystemBuildingError<BDE>> {
+    ) -> Result<Self, RemapOverlayFilesystemBuildingError<E>> {
         use wax::Pattern;
 
         let glob_keys: Result<Vec<wax::Glob>, _> = cfg
@@ -289,10 +284,6 @@ where
         Ok(Self {
             img_to_host,
             fs,
-
-            bde_type: core::marker::PhantomData,
-            bd_type: core::marker::PhantomData,
-            fs_type: core::marker::PhantomData,
         })
     }
 
@@ -323,14 +314,13 @@ where
 }
 
 #[maybe_async]
-impl<BDE, BD, FS> Filesystem<BD, RemapOverlayError<BDE>, BDE>
-    for RemapOverlayFilesystem<BDE, BD, FS>
-where
-    BDE: Into<RemapOverlayError<BDE>> + Send + Sync,
-    BD: BlockDeviceWrite<BDE>,
-    FS: Filesystem<BD, BDE>,
+impl<F> FilesystemHierarchy for RemapOverlayFilesystem<F>
+where 
+    F: FilesystemHierarchy,
 {
-    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, RemapOverlayError<BDE>> {
+    type Error = RemapOverlayError<F::Error>;
+
+    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, RemapOverlayError<F::Error>> {
         let dir = self
             .img_to_host
             .lookup_subdir(path)
@@ -347,35 +337,31 @@ where
         Ok(entries)
     }
 
+}
+
+#[maybe_async]
+impl<BDW, E, FS> FilesystemCopier<BDW>
+    for RemapOverlayFilesystem<FS>
+where
+    E: Into<RemapOverlayError<E>> + Send + Sync,
+    BDW: BlockDeviceWrite,
+    FS: FilesystemCopier<BDW, Error = E>,
+{
+    type Error = RemapOverlayError<E>;
+
     async fn copy_file_in(
         &mut self,
         src: &PathVec,
-        dest: &mut BD,
+        dest: &mut BDW,
         offset: u64,
         size: u64,
-    ) -> Result<u64, RemapOverlayError<BDE>> {
+    ) -> Result<u64, RemapOverlayError<E>> {
         let entry = self
             .img_to_host
             .get(src)
             .ok_or_else(|| RemapOverlayError::NoSuchFile(src.as_string()))?;
         self.fs
             .copy_file_in(&entry.host_path, dest, offset, size)
-            .await
-            .map_err(|e| e.into())
-    }
-
-    async fn copy_file_buf(
-        &mut self,
-        src: &PathVec,
-        buf: &mut [u8],
-        offset: u64,
-    ) -> Result<u64, RemapOverlayError<BDE>> {
-        let entry = self
-            .img_to_host
-            .get(src)
-            .ok_or_else(|| RemapOverlayError::NoSuchFile(src.as_string()))?;
-        self.fs
-            .copy_file_buf(&entry.host_path, buf, offset)
             .await
             .map_err(|e| e.into())
     }

--- a/xdvdfs-core/src/write/fs/sector_linear.rs
+++ b/xdvdfs-core/src/write/fs/sector_linear.rs
@@ -116,12 +116,15 @@ where
         &mut self,
         src: &PathVec,
         dest: &mut SectorLinearBlockDevice,
-        offset: u64,
+        input_offset: u64,
+        output_offset: u64,
         size: u64,
     ) -> Result<u64, Self::Error> {
-        let sector = offset / layout::SECTOR_SIZE as u64;
-        let offset = offset % layout::SECTOR_SIZE as u64;
-        assert_eq!(offset, 0);
+        assert_eq!(input_offset, 0);
+
+        let sector = output_offset / layout::SECTOR_SIZE as u64;
+        let output_offset = output_offset % layout::SECTOR_SIZE as u64;
+        assert_eq!(output_offset, 0);
 
         let mut sector_span = size / layout::SECTOR_SIZE as u64;
         if size % layout::SECTOR_SIZE as u64 > 0 {
@@ -199,6 +202,7 @@ where
                         path,
                         &mut buf,
                         sector_size as u64 * sector_idx,
+                        0,
                         sector_size as u64,
                     )
                     .await?;

--- a/xdvdfs-core/src/write/fs/sector_linear.rs
+++ b/xdvdfs-core/src/write/fs/sector_linear.rs
@@ -14,8 +14,7 @@ pub enum SectorLinearBlockContents {
     Empty,
 }
 
-#[derive(Clone, Debug)]
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SectorLinearBlockDevice {
     contents: alloc::collections::BTreeMap<u64, SectorLinearBlockContents>,
 }
@@ -148,7 +147,6 @@ impl SectorLinearBlockDevice {
         self.contents.len()
     }
 }
-
 
 impl core::ops::Index<u64> for SectorLinearBlockDevice {
     type Output = SectorLinearBlockContents;

--- a/xdvdfs-core/src/write/fs/sector_linear.rs
+++ b/xdvdfs-core/src/write/fs/sector_linear.rs
@@ -24,20 +24,17 @@ pub struct SectorLinearBlockFilesystem<'a, F> {
 }
 
 impl<'a, 'b, F> SectorLinearBlockFilesystem<'a, F>
-where 
-    F: FilesystemHierarchy + FilesystemCopier<Box<[u8]>>
+where
+    F: FilesystemHierarchy + FilesystemCopier<Box<[u8]>>,
 {
     pub fn new(fs: &'a mut F) -> Self {
-        Self {
-            fs,
-        }
+        Self { fs }
     }
 }
 
 impl SectorLinearBlockDevice {
     fn len_impl(&self) -> u64 {
-        self
-            .contents
+        self.contents
             .last_key_value()
             .map(|(sector, contents)| {
                 *sector * layout::SECTOR_SIZE as u64
@@ -47,7 +44,7 @@ impl SectorLinearBlockDevice {
                         SectorLinearBlockContents::Empty => 0,
                     } as u64
             })
-        .unwrap_or(0)
+            .unwrap_or(0)
     }
 }
 
@@ -98,7 +95,8 @@ impl BlockDeviceWrite for SectorLinearBlockDevice {
 
 #[maybe_async]
 impl<F> FilesystemHierarchy for SectorLinearBlockFilesystem<'_, F>
-where F: FilesystemHierarchy
+where
+    F: FilesystemHierarchy,
 {
     type Error = <F as FilesystemHierarchy>::Error;
 
@@ -110,7 +108,7 @@ where F: FilesystemHierarchy
 #[maybe_async]
 impl<'a, F> FilesystemCopier<SectorLinearBlockDevice> for SectorLinearBlockFilesystem<'_, F>
 where
-    F: FilesystemCopier<Box<[u8]>>
+    F: FilesystemCopier<Box<[u8]>>,
 {
     type Error = Infallible;
 
@@ -176,14 +174,8 @@ pub struct CisoSectorInput<'a, F> {
 
 #[cfg(feature = "ciso_support")]
 impl<'a, F> CisoSectorInput<'a, F> {
-    pub fn new(
-        bdev: SectorLinearBlockDevice,
-        fs: SectorLinearBlockFilesystem<'a, F>,
-    ) -> Self {
-        Self {
-            linear: bdev,
-            fs,
-        }
+    pub fn new(bdev: SectorLinearBlockDevice, fs: SectorLinearBlockFilesystem<'a, F>) -> Self {
+        Self { linear: bdev, fs }
     }
 }
 
@@ -212,7 +204,12 @@ where
                 let bytes_read = self
                     .fs
                     .fs
-                    .copy_file_in(path, &mut buf_box, sector_size as u64 * sector_idx, sector_size as u64)
+                    .copy_file_in(
+                        path,
+                        &mut buf_box,
+                        sector_size as u64 * sector_idx,
+                        sector_size as u64,
+                    )
                     .await?;
                 assert_eq!(bytes_read, sector_size as u64);
                 buf = buf_box.into_vec();

--- a/xdvdfs-core/src/write/fs/sector_linear.rs
+++ b/xdvdfs-core/src/write/fs/sector_linear.rs
@@ -1,9 +1,11 @@
+use core::convert::Infallible;
+
 use crate::{blockdev::BlockDeviceWrite, layout};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use maybe_async::maybe_async;
 
-use super::{FileEntry, Filesystem, PathVec};
+use super::{FileEntry, FilesystemCopier, FilesystemHierarchy, PathVec};
 
 #[derive(Clone, Debug)]
 pub enum SectorLinearBlockContents {
@@ -13,33 +15,47 @@ pub enum SectorLinearBlockContents {
 }
 
 #[derive(Clone, Debug)]
-pub struct SectorLinearBlockDevice<E> {
+pub struct SectorLinearBlockDevice {
     contents: alloc::collections::BTreeMap<u64, SectorLinearBlockContents>,
-
-    err_t: core::marker::PhantomData<E>,
 }
 
-pub struct SectorLinearBlockFilesystem<'a, E, W: BlockDeviceWrite<E>, F: Filesystem<W, E>> {
+pub struct SectorLinearBlockFilesystem<'a, F> {
     fs: &'a mut F,
-
-    err_t: core::marker::PhantomData<E>,
-    bdev_t: core::marker::PhantomData<W>,
 }
 
-impl<'a, E, W: BlockDeviceWrite<E>, F: Filesystem<W, E>> SectorLinearBlockFilesystem<'a, E, W, F> {
+impl<'a, 'b, F> SectorLinearBlockFilesystem<'a, F>
+where 
+    F: FilesystemHierarchy + FilesystemCopier<Box<[u8]>>
+{
     pub fn new(fs: &'a mut F) -> Self {
         Self {
             fs,
-
-            err_t: core::marker::PhantomData,
-            bdev_t: core::marker::PhantomData,
         }
     }
 }
 
+impl SectorLinearBlockDevice {
+    fn len_impl(&self) -> u64 {
+        self
+            .contents
+            .last_key_value()
+            .map(|(sector, contents)| {
+                *sector * layout::SECTOR_SIZE as u64
+                    + match contents {
+                        SectorLinearBlockContents::RawData(_) => layout::SECTOR_SIZE,
+                        SectorLinearBlockContents::File(_, _) => layout::SECTOR_SIZE,
+                        SectorLinearBlockContents::Empty => 0,
+                    } as u64
+            })
+        .unwrap_or(0)
+    }
+}
+
 #[maybe_async]
-impl<E: Send + Sync> BlockDeviceWrite<E> for SectorLinearBlockDevice<E> {
-    async fn write(&mut self, offset: u64, buffer: &[u8]) -> Result<(), E> {
+impl BlockDeviceWrite for SectorLinearBlockDevice {
+    type WriteError = Infallible;
+
+    async fn write(&mut self, offset: u64, buffer: &[u8]) -> Result<(), Infallible> {
         let mut remaining = buffer.len();
         let mut buffer_pos = 0;
 
@@ -75,40 +91,36 @@ impl<E: Send + Sync> BlockDeviceWrite<E> for SectorLinearBlockDevice<E> {
         Ok(())
     }
 
-    async fn len(&mut self) -> Result<u64, E> {
-        Ok(self
-            .contents
-            .last_key_value()
-            .map(|(sector, contents)| {
-                *sector * layout::SECTOR_SIZE as u64
-                    + match contents {
-                        SectorLinearBlockContents::RawData(_) => layout::SECTOR_SIZE,
-                        SectorLinearBlockContents::File(_, _) => layout::SECTOR_SIZE,
-                        SectorLinearBlockContents::Empty => 0,
-                    } as u64
-            })
-            .unwrap_or(0))
+    async fn len(&mut self) -> Result<u64, Infallible> {
+        Ok(self.len_impl())
     }
 }
 
 #[maybe_async]
-impl<E, W, F> Filesystem<SectorLinearBlockDevice<E>, E> for SectorLinearBlockFilesystem<'_, E, W, F>
-where
-    W: BlockDeviceWrite<E>,
-    F: Filesystem<W, E>,
-    E: Send + Sync,
+impl<F> FilesystemHierarchy for SectorLinearBlockFilesystem<'_, F>
+where F: FilesystemHierarchy
 {
-    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, E> {
+    type Error = <F as FilesystemHierarchy>::Error;
+
+    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, Self::Error> {
         self.fs.read_dir(path).await
     }
+}
+
+#[maybe_async]
+impl<'a, F> FilesystemCopier<SectorLinearBlockDevice> for SectorLinearBlockFilesystem<'_, F>
+where
+    F: FilesystemCopier<Box<[u8]>>
+{
+    type Error = Infallible;
 
     async fn copy_file_in(
         &mut self,
         src: &PathVec,
-        dest: &mut SectorLinearBlockDevice<E>,
+        dest: &mut SectorLinearBlockDevice,
         offset: u64,
         size: u64,
-    ) -> Result<u64, E> {
+    ) -> Result<u64, Self::Error> {
         let sector = offset / layout::SECTOR_SIZE as u64;
         let offset = offset % layout::SECTOR_SIZE as u64;
         assert_eq!(offset, 0);
@@ -130,33 +142,23 @@ where
 
         Ok(size)
     }
-
-    async fn copy_file_buf(
-        &mut self,
-        _src: &PathVec,
-        _buf: &mut [u8],
-        _offset: u64,
-    ) -> Result<u64, E> {
-        unimplemented!();
-    }
 }
 
-impl<E> SectorLinearBlockDevice<E> {
+impl SectorLinearBlockDevice {
     pub fn num_sectors(&self) -> usize {
         self.contents.len()
     }
 }
 
-impl<E> Default for SectorLinearBlockDevice<E> {
+impl Default for SectorLinearBlockDevice {
     fn default() -> Self {
         Self {
             contents: alloc::collections::BTreeMap::new(),
-            err_t: core::marker::PhantomData,
         }
     }
 }
 
-impl<E> core::ops::Index<u64> for SectorLinearBlockDevice<E> {
+impl core::ops::Index<u64> for SectorLinearBlockDevice {
     type Output = SectorLinearBlockContents;
 
     fn index(&self, index: u64) -> &Self::Output {
@@ -167,45 +169,37 @@ impl<E> core::ops::Index<u64> for SectorLinearBlockDevice<E> {
 }
 
 #[cfg(feature = "ciso_support")]
-pub struct CisoSectorInput<'a, E: Send + Sync, W: BlockDeviceWrite<E>, F: Filesystem<W, E>> {
-    linear: SectorLinearBlockDevice<E>,
-    fs: SectorLinearBlockFilesystem<'a, E, W, F>,
-
-    bdev_t: core::marker::PhantomData<W>,
+pub struct CisoSectorInput<'a, F> {
+    linear: SectorLinearBlockDevice,
+    fs: SectorLinearBlockFilesystem<'a, F>,
 }
 
 #[cfg(feature = "ciso_support")]
-impl<'a, E, W, F> CisoSectorInput<'a, E, W, F>
-where
-    W: BlockDeviceWrite<E>,
-    F: Filesystem<W, E>,
-    E: Send + Sync,
-{
+impl<'a, F> CisoSectorInput<'a, F> {
     pub fn new(
-        bdev: SectorLinearBlockDevice<E>,
-        fs: SectorLinearBlockFilesystem<'a, E, W, F>,
+        bdev: SectorLinearBlockDevice,
+        fs: SectorLinearBlockFilesystem<'a, F>,
     ) -> Self {
         Self {
             linear: bdev,
             fs,
-            bdev_t: core::marker::PhantomData,
         }
     }
 }
 
 #[cfg(feature = "ciso_support")]
 #[maybe_async]
-impl<E, W, F> ciso::write::SectorReader<E> for CisoSectorInput<'_, E, W, F>
+impl<F, FSE> ciso::write::SectorReader for CisoSectorInput<'_, F>
 where
-    W: BlockDeviceWrite<E>,
-    F: Filesystem<W, E>,
-    E: Send + Sync,
+    F: FilesystemCopier<Box<[u8]>, Error = FSE>,
 {
-    async fn size(&mut self) -> Result<u64, E> {
-        self.linear.len().await
+    type ReadError = FSE;
+
+    async fn size(&mut self) -> Result<u64, FSE> {
+        Ok(self.linear.len_impl())
     }
 
-    async fn read_sector(&mut self, sector: usize, sector_size: u32) -> Result<Vec<u8>, E> {
+    async fn read_sector(&mut self, sector: usize, sector_size: u32) -> Result<Vec<u8>, FSE> {
         let mut buf = alloc::vec![0; sector_size as usize];
 
         match &self.linear[sector as u64] {
@@ -214,12 +208,14 @@ where
                 buf.copy_from_slice(data.as_slice());
             }
             SectorLinearBlockContents::File(path, sector_idx) => {
+                let mut buf_box = buf.into_boxed_slice();
                 let bytes_read = self
                     .fs
                     .fs
-                    .copy_file_buf(path, &mut buf, sector_size as u64 * sector_idx)
+                    .copy_file_in(path, &mut buf_box, sector_size as u64 * sector_idx, sector_size as u64)
                     .await?;
                 assert_eq!(bytes_read, sector_size as u64);
+                buf = buf_box.into_vec();
             }
         };
 

--- a/xdvdfs-core/src/write/fs/sector_linear.rs
+++ b/xdvdfs-core/src/write/fs/sector_linear.rs
@@ -15,6 +15,7 @@ pub enum SectorLinearBlockContents {
 }
 
 #[derive(Clone, Debug)]
+#[derive(Default)]
 pub struct SectorLinearBlockDevice {
     contents: alloc::collections::BTreeMap<u64, SectorLinearBlockContents>,
 }
@@ -23,7 +24,7 @@ pub struct SectorLinearBlockFilesystem<'a, F> {
     fs: &'a mut F,
 }
 
-impl<'a, 'b, F> SectorLinearBlockFilesystem<'a, F>
+impl<'a, F> SectorLinearBlockFilesystem<'a, F>
 where
     F: FilesystemHierarchy + FilesystemCopier<Box<[u8]>>,
 {
@@ -106,7 +107,7 @@ where
 }
 
 #[maybe_async]
-impl<'a, F> FilesystemCopier<SectorLinearBlockDevice> for SectorLinearBlockFilesystem<'_, F>
+impl<F> FilesystemCopier<SectorLinearBlockDevice> for SectorLinearBlockFilesystem<'_, F>
 where
     F: FilesystemCopier<Box<[u8]>>,
 {
@@ -148,13 +149,6 @@ impl SectorLinearBlockDevice {
     }
 }
 
-impl Default for SectorLinearBlockDevice {
-    fn default() -> Self {
-        Self {
-            contents: alloc::collections::BTreeMap::new(),
-        }
-    }
-}
 
 impl core::ops::Index<u64> for SectorLinearBlockDevice {
     type Output = SectorLinearBlockContents;

--- a/xdvdfs-core/src/write/fs/stdfs.rs
+++ b/xdvdfs-core/src/write/fs/stdfs.rs
@@ -67,7 +67,6 @@ impl FilesystemHierarchy for StdFilesystem {
         listing
     }
 
-
     fn path_to_string(&self, path: &PathVec) -> String {
         let path = path.as_path_buf(&self.root);
         format!("{:?}", path)

--- a/xdvdfs-core/src/write/fs/stdfs.rs
+++ b/xdvdfs-core/src/write/fs/stdfs.rs
@@ -99,13 +99,13 @@ where
 }
 
 #[maybe_async]
-impl FilesystemCopier<Box<[u8]>> for StdFilesystem {
+impl FilesystemCopier<alloc::boxed::Box<[u8]>> for StdFilesystem {
     type Error = std::io::Error;
 
     async fn copy_file_in(
         &mut self,
         src: &PathVec,
-        dest: &mut Box<[u8]>,
+        dest: &mut alloc::boxed::Box<[u8]>,
         offset: u64,
         _size: u64,
     ) -> Result<u64, std::io::Error> {
@@ -123,13 +123,13 @@ impl FilesystemCopier<Box<[u8]>> for StdFilesystem {
 }
 
 #[maybe_async]
-impl<'a> FilesystemCopier<&'a mut [u8]> for StdFilesystem {
+impl FilesystemCopier<[u8]> for StdFilesystem {
     type Error = std::io::Error;
 
     async fn copy_file_in(
         &mut self,
         src: &PathVec,
-        dest: &mut &'a mut [u8],
+        dest: &mut [u8],
         offset: u64,
         _size: u64,
     ) -> Result<u64, std::io::Error> {

--- a/xdvdfs-core/src/write/fs/xdvdfs.rs
+++ b/xdvdfs-core/src/write/fs/xdvdfs.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use core::error::Error;
 use core::fmt::Debug;
 use core::fmt::Display;
 
@@ -13,7 +14,58 @@ use crate::{
     util,
 };
 
-use super::{FileEntry, FileType, Filesystem, PathPrefixTree, PathVec};
+use super::FilesystemCopier;
+use super::FilesystemHierarchy;
+use super::{FileEntry, FileType, PathPrefixTree, PathVec};
+
+/// Error type for XDVDFSFilesystem operations
+/// A BlockDev error is an error that occurred during a copy operation
+/// in the respective block device side.
+/// A FilesystemReadErr is an error that occurred while traversing the
+/// underlying XDVDFS filesystem.
+#[derive(Debug)]
+pub enum XDVDFSFilesystemError<ReadErr, WriteErr> {
+    FilesystemReadErr(util::Error<ReadErr>),
+    BlockDevReadErr(ReadErr),
+    BlockDevWriteErr(WriteErr),
+}
+
+impl<ReadErr, WriteErr> XDVDFSFilesystemError<ReadErr, WriteErr> {
+    fn to_str(&self) -> &str {
+        match self {
+            Self::FilesystemReadErr(_) => "Failed to read XDVDFS filesystem",
+            Self::BlockDevReadErr(_) => "Failed to read from block device",
+            Self::BlockDevWriteErr(_) => "Failed to write to block device",
+        }
+    }
+}
+
+impl<ReadErr: Display, WriteErr: Display> Display for XDVDFSFilesystemError<ReadErr, WriteErr>
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.to_str())?;
+        f.write_str(": ")?;
+        match self {
+            Self::FilesystemReadErr(ref e) => Display::fmt(e, f),
+            Self::BlockDevReadErr(ref e) => Display::fmt(e, f),
+            Self::BlockDevWriteErr(ref e) => Display::fmt(e, f),
+        }
+    }
+}
+
+impl<ReadErr, WriteErr> Error for XDVDFSFilesystemError<ReadErr, WriteErr> 
+where
+    ReadErr: Debug + Display + Error + 'static,
+    WriteErr: Debug + Display + Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::FilesystemReadErr(ref e) => Some(e),
+            Self::BlockDevReadErr(ref e) => Some(e),
+            Self::BlockDevWriteErr(ref e) => Some(e),
+        }
+    }
+}
 
 /// Copy specialization for underlying XDVDFSFilesystem block devices
 /// The default implementation of `copy` makes no assumptions about the
@@ -21,10 +73,10 @@ use super::{FileEntry, FileType, Filesystem, PathPrefixTree, PathVec};
 /// Override this trait if making assumptions about your block devices
 /// allows for optimizing copies between them.
 #[maybe_async]
-pub trait RWCopier<E, R, W>
+pub trait RWCopier<R, W>
 where
-    R: BlockDeviceRead<E>,
-    W: BlockDeviceWrite<E>,
+    R: BlockDeviceRead + ?Sized,
+    W: BlockDeviceWrite + ?Sized,
 {
     async fn copy(
         offset_in: u64,
@@ -32,7 +84,7 @@ where
         size: u64,
         src: &mut R,
         dest: &mut W,
-    ) -> Result<u64, E> {
+    ) -> Result<u64, XDVDFSFilesystemError<R::ReadError, W::WriteError>> {
         let buf_size = 1024 * 1024;
         let mut buf = alloc::vec![0; buf_size as usize].into_boxed_slice();
         let mut copied = 0;
@@ -40,8 +92,12 @@ where
             let to_copy = core::cmp::min(buf_size, size - copied);
             let slice = &mut buf[0..to_copy.try_into().unwrap()];
 
-            src.read(offset_in + copied, slice).await?;
-            dest.write(offset_out + copied, slice).await?;
+            src.read(offset_in + copied, slice)
+                .await
+                .map_err(|e| XDVDFSFilesystemError::BlockDevReadErr(e))?;
+            dest.write(offset_out + copied, slice)
+                .await
+                .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))?;
             copied += to_copy;
         }
 
@@ -52,16 +108,15 @@ where
 
 /// Default copier specialization, uses the default
 /// RWCopier implementation for all inputs
-pub struct DefaultCopier<E, R, W> {
-    e_type: core::marker::PhantomData<E>,
+pub struct DefaultCopier<R, W> {
     r_type: core::marker::PhantomData<R>,
     w_type: core::marker::PhantomData<W>,
 }
 
-impl<E, R, W> RWCopier<E, R, W> for DefaultCopier<E, R, W>
+impl<R, W> RWCopier<R, W> for DefaultCopier<R, W>
 where
-    R: BlockDeviceRead<E>,
-    W: BlockDeviceWrite<E>,
+    R: BlockDeviceRead,
+    W: BlockDeviceWrite,
 {
 }
 
@@ -70,18 +125,16 @@ where
 /// or block devices that implement the above and are wrapped by
 /// `xdvdfs::blockdev::OffsetWrapper` and specializes the copy to use
 /// `std::io::copy`
-pub struct StdIOCopier<E, R, W> {
-    e_type: core::marker::PhantomData<E>,
+pub struct StdIOCopier<R, W> {
     r_type: core::marker::PhantomData<R>,
     w_type: core::marker::PhantomData<W>,
 }
 
 #[maybe_async]
-impl<E, R, W> RWCopier<E, R, W> for StdIOCopier<E, R, W>
+impl<R, W> RWCopier<R, W> for StdIOCopier<R, W>
 where
-    E: From<std::io::Error>,
-    R: BlockDeviceRead<E> + std::io::Read + std::io::Seek + Sized,
-    W: BlockDeviceWrite<E> + std::io::Write + std::io::Seek,
+    R: BlockDeviceRead<ReadError = std::io::Error> + std::io::Read + std::io::Seek + Sized,
+    W: BlockDeviceWrite<WriteError = std::io::Error> + std::io::Write + std::io::Seek,
 {
     async fn copy(
         offset_in: u64,
@@ -89,62 +142,68 @@ where
         size: u64,
         src: &mut R,
         dest: &mut W,
-    ) -> Result<u64, E> {
+    ) -> Result<u64, XDVDFSFilesystemError<std::io::Error, std::io::Error>> {
         use std::io::{Read, SeekFrom};
-        src.seek(SeekFrom::Start(offset_in))?;
-        dest.seek(SeekFrom::Start(offset_out))?;
+        src.seek(SeekFrom::Start(offset_in))
+                .map_err(|e| XDVDFSFilesystemError::BlockDevReadErr(e))?;
+        dest.seek(SeekFrom::Start(offset_out))
+                .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))?;
 
-        std::io::copy(&mut src.by_ref().take(size), dest).map_err(|e| e.into())
+        // Arbitrarily assign copy errors to the write side,
+        // we can't differentiate them anyway
+        std::io::copy(&mut src.by_ref().take(size), dest).map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))
     }
 }
 
 #[maybe_async]
-impl<E, R, W> RWCopier<E, crate::blockdev::OffsetWrapper<R, E>, W>
-    for StdIOCopier<E, crate::blockdev::OffsetWrapper<R, E>, W>
+impl<R, W> RWCopier<crate::blockdev::OffsetWrapper<R>, W>
+    for StdIOCopier<crate::blockdev::OffsetWrapper<R>, W>
 where
-    E: Send + Sync + From<std::io::Error>,
-    R: BlockDeviceRead<E> + std::io::Read + std::io::Seek,
-    W: BlockDeviceWrite<E> + std::io::Write + std::io::Seek,
+    R: BlockDeviceRead<ReadError = std::io::Error> + std::io::Read + std::io::Seek,
+    W: BlockDeviceWrite<WriteError = std::io::Error> + std::io::Write + std::io::Seek,
 {
     async fn copy(
         offset_in: u64,
         offset_out: u64,
         size: u64,
-        src: &mut crate::blockdev::OffsetWrapper<R, E>,
+        src: &mut crate::blockdev::OffsetWrapper<R>,
         dest: &mut W,
-    ) -> Result<u64, E> {
+    ) -> Result<u64, XDVDFSFilesystemError<std::io::Error, std::io::Error>> {
         use std::io::{Read, Seek, SeekFrom};
-        src.seek(SeekFrom::Start(offset_in))?;
-        dest.seek(SeekFrom::Start(offset_out))?;
+        src.seek(SeekFrom::Start(offset_in))
+                .map_err(|e| XDVDFSFilesystemError::BlockDevReadErr(e))?;
+        dest.seek(SeekFrom::Start(offset_out))
+                .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))?;
 
-        std::io::copy(&mut src.get_mut().by_ref().take(size), dest).map_err(|e| e.into())
+        // Arbitrarily assign copy errors to the write side,
+        // we can't differentiate them anyway
+        std::io::copy(&mut src.get_mut().by_ref().take(size), dest).map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))
     }
 }
 
 /// A Filesystem backed by an XDVDFS block device
 /// Reads entries and data from a supplied XDVDFS image
-pub struct XDVDFSFilesystem<E, D, W, Copier = DefaultCopier<E, D, W>>
+pub struct XDVDFSFilesystem<D, W, Copier = DefaultCopier<D, W>>
 where
-    D: BlockDeviceRead<E> + Sized,
-    W: BlockDeviceWrite<E>,
+    D: BlockDeviceRead + Sized,
+    W: BlockDeviceWrite + ?Sized,
 {
     dev: D,
     volume: crate::layout::VolumeDescriptor,
     dirent_cache: PathPrefixTree<DirectoryEntryNode>,
 
-    e_type: core::marker::PhantomData<E>,
     w_type: core::marker::PhantomData<W>,
     copier_type: core::marker::PhantomData<Copier>,
 }
 
-impl<E, D, W, Copier> XDVDFSFilesystem<E, D, W, Copier>
+impl<D, W, Copier> XDVDFSFilesystem<D, W, Copier>
 where
-    D: BlockDeviceRead<E> + Sized,
-    W: BlockDeviceWrite<E>,
-    Copier: RWCopier<E, D, W>,
+    D: BlockDeviceRead + Sized,
+    W: BlockDeviceWrite,
+    Copier: RWCopier<D, W>,
 {
     #[maybe_async]
-    pub async fn new(mut dev: D) -> Option<XDVDFSFilesystem<E, D, W, Copier>> {
+    pub async fn new(mut dev: D) -> Option<XDVDFSFilesystem<D, W, Copier>> {
         let volume = crate::read::read_volume(&mut dev).await;
 
         if let Ok(volume) = volume {
@@ -152,7 +211,6 @@ where
                 dev,
                 volume,
                 dirent_cache: PathPrefixTree::default(),
-                e_type: core::marker::PhantomData,
                 w_type: core::marker::PhantomData,
                 copier_type: core::marker::PhantomData,
             })
@@ -172,14 +230,15 @@ where
 }
 
 #[maybe_async]
-impl<E, D, W, Copier> Filesystem<W, E> for XDVDFSFilesystem<E, D, W, Copier>
+impl<D, W, Copier> FilesystemHierarchy for XDVDFSFilesystem<D, W, Copier> 
 where
-    E: From<util::Error<E>> + Send + Sync,
-    D: BlockDeviceRead<E> + Sized,
-    W: BlockDeviceWrite<E>,
-    Copier: RWCopier<E, D, W> + Send + Sync,
+    D: BlockDeviceRead + Sized,
+    W: BlockDeviceWrite,
+    Copier: RWCopier<D, W> + Send + Sync,
 {
-    async fn read_dir(&mut self, dir: &PathVec) -> Result<Vec<FileEntry>, E> {
+    type Error = util::Error<D::ReadError>;
+
+    async fn read_dir(&mut self, dir: &PathVec) -> Result<Vec<FileEntry>, Self::Error> {
         let (dirtab, cache_node) = if dir.is_root() {
             (self.volume.root_table, &mut self.dirent_cache)
         } else {
@@ -220,6 +279,16 @@ where
 
         Ok(entries)
     }
+}
+
+#[maybe_async]
+impl<D, W, Copier> FilesystemCopier<W> for XDVDFSFilesystem<D, W, Copier>
+where
+    D: BlockDeviceRead + Sized,
+    W: BlockDeviceWrite + ?Sized,
+    Copier: RWCopier<D, W> + Send + Sync,
+{
+    type Error = XDVDFSFilesystemError<D::ReadError, W::WriteError>;
 
     async fn copy_file_in(
         &mut self,
@@ -227,18 +296,21 @@ where
         dest: &mut W,
         offset: u64,
         size: u64,
-    ) -> Result<u64, E> {
-        let dirent = self.dirent_cache.get(src).ok_or(util::Error::NoDirent)?;
+    ) -> Result<u64, Self::Error> {
+        let dirent = self.dirent_cache.get(src)
+            .ok_or(XDVDFSFilesystemError::FilesystemReadErr(util::Error::NoDirent))?;
 
         let size_to_copy = core::cmp::min(size, dirent.node.dirent.data.size as u64);
         if size_to_copy == 0 {
             return Ok(0);
         }
 
-        let offset_in = dirent.node.dirent.data.offset(0)?;
+        let offset_in = dirent.node.dirent.data.offset(0)
+            .map_err(|e| XDVDFSFilesystemError::FilesystemReadErr(e))?;
         Copier::copy(offset_in, offset, size_to_copy, &mut self.dev, dest).await
     }
 
+    /*
     async fn copy_file_buf(
         &mut self,
         src: &PathVec,
@@ -265,4 +337,5 @@ where
         buf[(to_copy as usize)..].fill(0);
         Ok(buf_size as u64)
     }
+    */
 }

--- a/xdvdfs-core/src/write/fs/xdvdfs.rs
+++ b/xdvdfs-core/src/write/fs/xdvdfs.rs
@@ -93,10 +93,10 @@ where
 
             src.read(offset_in + copied, slice)
                 .await
-                .map_err(|e| XDVDFSFilesystemError::BlockDevReadErr(e))?;
+                .map_err(XDVDFSFilesystemError::BlockDevReadErr)?;
             dest.write(offset_out + copied, slice)
                 .await
-                .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))?;
+                .map_err(XDVDFSFilesystemError::BlockDevWriteErr)?;
             copied += to_copy;
         }
 
@@ -144,14 +144,14 @@ where
     ) -> Result<u64, XDVDFSFilesystemError<std::io::Error, std::io::Error>> {
         use std::io::{Read, SeekFrom};
         src.seek(SeekFrom::Start(offset_in))
-            .map_err(|e| XDVDFSFilesystemError::BlockDevReadErr(e))?;
+            .map_err(XDVDFSFilesystemError::BlockDevReadErr)?;
         dest.seek(SeekFrom::Start(offset_out))
-            .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))?;
+            .map_err(XDVDFSFilesystemError::BlockDevWriteErr)?;
 
         // Arbitrarily assign copy errors to the write side,
         // we can't differentiate them anyway
         std::io::copy(&mut src.by_ref().take(size), dest)
-            .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))
+            .map_err(XDVDFSFilesystemError::BlockDevWriteErr)
     }
 }
 
@@ -171,14 +171,14 @@ where
     ) -> Result<u64, XDVDFSFilesystemError<std::io::Error, std::io::Error>> {
         use std::io::{Read, Seek, SeekFrom};
         src.seek(SeekFrom::Start(offset_in))
-            .map_err(|e| XDVDFSFilesystemError::BlockDevReadErr(e))?;
+            .map_err(XDVDFSFilesystemError::BlockDevReadErr)?;
         dest.seek(SeekFrom::Start(offset_out))
-            .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))?;
+            .map_err(XDVDFSFilesystemError::BlockDevWriteErr)?;
 
         // Arbitrarily assign copy errors to the write side,
         // we can't differentiate them anyway
         std::io::copy(&mut src.get_mut().by_ref().take(size), dest)
-            .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))
+            .map_err(XDVDFSFilesystemError::BlockDevWriteErr)
     }
 }
 
@@ -315,7 +315,7 @@ where
             .dirent
             .data
             .offset(0)
-            .map_err(|e| XDVDFSFilesystemError::FilesystemReadErr(e))?;
+            .map_err(XDVDFSFilesystemError::FilesystemReadErr)?;
         Copier::copy(offset_in, offset, size_to_copy, &mut self.dev, dest).await
     }
 

--- a/xdvdfs-core/src/write/fs/xdvdfs.rs
+++ b/xdvdfs-core/src/write/fs/xdvdfs.rs
@@ -89,7 +89,7 @@ where
         let mut copied = 0;
         while copied < size {
             let to_copy = core::cmp::min(buf_size, size - copied);
-            let slice = &mut buf[0..to_copy.try_into().unwrap()];
+            let slice = &mut buf[0..(to_copy as usize)];
 
             src.read(offset_in + copied, slice)
                 .await
@@ -295,7 +295,8 @@ where
         &mut self,
         src: &PathVec,
         dest: &mut W,
-        offset: u64,
+        input_offset: u64,
+        output_offset: u64,
         size: u64,
     ) -> Result<u64, Self::Error> {
         let dirent = self
@@ -310,12 +311,19 @@ where
             return Ok(0);
         }
 
-        let offset_in = dirent
+        let input_offset = dirent
             .node
             .dirent
             .data
-            .offset(0)
+            .offset(input_offset)
             .map_err(XDVDFSFilesystemError::FilesystemReadErr)?;
-        Copier::copy(offset_in, offset, size_to_copy, &mut self.dev, dest).await
+        Copier::copy(
+            input_offset,
+            output_offset,
+            size_to_copy,
+            &mut self.dev,
+            dest,
+        )
+        .await
     }
 }

--- a/xdvdfs-core/src/write/fs/xdvdfs.rs
+++ b/xdvdfs-core/src/write/fs/xdvdfs.rs
@@ -40,8 +40,7 @@ impl<ReadErr, WriteErr> XDVDFSFilesystemError<ReadErr, WriteErr> {
     }
 }
 
-impl<ReadErr: Display, WriteErr: Display> Display for XDVDFSFilesystemError<ReadErr, WriteErr>
-{
+impl<ReadErr: Display, WriteErr: Display> Display for XDVDFSFilesystemError<ReadErr, WriteErr> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(self.to_str())?;
         f.write_str(": ")?;
@@ -53,7 +52,7 @@ impl<ReadErr: Display, WriteErr: Display> Display for XDVDFSFilesystemError<Read
     }
 }
 
-impl<ReadErr, WriteErr> Error for XDVDFSFilesystemError<ReadErr, WriteErr> 
+impl<ReadErr, WriteErr> Error for XDVDFSFilesystemError<ReadErr, WriteErr>
 where
     ReadErr: Debug + Display + Error + 'static,
     WriteErr: Debug + Display + Error + 'static,
@@ -145,13 +144,14 @@ where
     ) -> Result<u64, XDVDFSFilesystemError<std::io::Error, std::io::Error>> {
         use std::io::{Read, SeekFrom};
         src.seek(SeekFrom::Start(offset_in))
-                .map_err(|e| XDVDFSFilesystemError::BlockDevReadErr(e))?;
+            .map_err(|e| XDVDFSFilesystemError::BlockDevReadErr(e))?;
         dest.seek(SeekFrom::Start(offset_out))
-                .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))?;
+            .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))?;
 
         // Arbitrarily assign copy errors to the write side,
         // we can't differentiate them anyway
-        std::io::copy(&mut src.by_ref().take(size), dest).map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))
+        std::io::copy(&mut src.by_ref().take(size), dest)
+            .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))
     }
 }
 
@@ -171,13 +171,14 @@ where
     ) -> Result<u64, XDVDFSFilesystemError<std::io::Error, std::io::Error>> {
         use std::io::{Read, Seek, SeekFrom};
         src.seek(SeekFrom::Start(offset_in))
-                .map_err(|e| XDVDFSFilesystemError::BlockDevReadErr(e))?;
+            .map_err(|e| XDVDFSFilesystemError::BlockDevReadErr(e))?;
         dest.seek(SeekFrom::Start(offset_out))
-                .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))?;
+            .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))?;
 
         // Arbitrarily assign copy errors to the write side,
         // we can't differentiate them anyway
-        std::io::copy(&mut src.get_mut().by_ref().take(size), dest).map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))
+        std::io::copy(&mut src.get_mut().by_ref().take(size), dest)
+            .map_err(|e| XDVDFSFilesystemError::BlockDevWriteErr(e))
     }
 }
 
@@ -230,7 +231,7 @@ where
 }
 
 #[maybe_async]
-impl<D, W, Copier> FilesystemHierarchy for XDVDFSFilesystem<D, W, Copier> 
+impl<D, W, Copier> FilesystemHierarchy for XDVDFSFilesystem<D, W, Copier>
 where
     D: BlockDeviceRead + Sized,
     W: BlockDeviceWrite,
@@ -297,15 +298,23 @@ where
         offset: u64,
         size: u64,
     ) -> Result<u64, Self::Error> {
-        let dirent = self.dirent_cache.get(src)
-            .ok_or(XDVDFSFilesystemError::FilesystemReadErr(util::Error::NoDirent))?;
+        let dirent = self
+            .dirent_cache
+            .get(src)
+            .ok_or(XDVDFSFilesystemError::FilesystemReadErr(
+                util::Error::NoDirent,
+            ))?;
 
         let size_to_copy = core::cmp::min(size, dirent.node.dirent.data.size as u64);
         if size_to_copy == 0 {
             return Ok(0);
         }
 
-        let offset_in = dirent.node.dirent.data.offset(0)
+        let offset_in = dirent
+            .node
+            .dirent
+            .data
+            .offset(0)
             .map_err(|e| XDVDFSFilesystemError::FilesystemReadErr(e))?;
         Copier::copy(offset_in, offset, size_to_copy, &mut self.dev, dest).await
     }

--- a/xdvdfs-core/src/write/img.rs
+++ b/xdvdfs-core/src/write/img.rs
@@ -103,6 +103,12 @@ fn create_dirent_tables<'a>(
     Ok(dirent_tables)
 }
 
+type GenericWriteError<BDW, FS> = WriteError<
+    <BDW as BlockDeviceWrite>::WriteError,
+    <FS as FilesystemHierarchy>::Error,
+    <FS as FilesystemCopier<BDW>>::Error,
+>;
+
 #[maybe_async]
 pub async fn create_xdvdfs_image<
     BDW: BlockDeviceWrite,
@@ -111,14 +117,7 @@ pub async fn create_xdvdfs_image<
     fs: &mut FS,
     image: &mut BDW,
     mut progress_callback: impl FnMut(ProgressInfo),
-) -> Result<
-    (),
-    WriteError<
-        BDW::WriteError,
-        <FS as FilesystemHierarchy>::Error,
-        <FS as FilesystemCopier<BDW>>::Error,
-    >,
-> {
+) -> Result<(), GenericWriteError<BDW, FS>> {
     // We need to compute the size of all dirent tables before
     // writing the image. As such, we iterate over a directory tree
     // in reverse order, such that dirents for leaf directories

--- a/xdvdfs-core/src/write/img.rs
+++ b/xdvdfs-core/src/write/img.rs
@@ -172,6 +172,7 @@ pub async fn create_xdvdfs_image<
                 fs.copy_file_in(
                     &file_path,
                     image,
+                    0,
                     entry.sector * layout::SECTOR_SIZE as u64,
                     entry.size,
                 )

--- a/xdvdfs-core/src/write/mod.rs
+++ b/xdvdfs-core/src/write/mod.rs
@@ -1,5 +1,111 @@
+use core::error::Error;
+use core::fmt::{Debug, Display};
+
 mod avl;
 pub mod dirtab;
 pub mod fs;
 pub mod img;
 pub mod sector;
+
+/// Contains variants of WriteError that are not specific to
+/// the block device or filesystem. This allows us to pass errors
+/// around the write module without having to carry around the generics.
+#[derive(Debug)]
+pub enum FileStructureError {
+    SerializationError(bincode::Error),
+    StringEncodingError,
+    FileNameTooLong,
+    DuplicateFileName,
+    TooManyDirectoryEntries,
+    FileTooLarge,
+}
+
+#[derive(Debug)]
+pub enum WriteError<BlockDevError, FSHierarchyError, FSCopierError> {
+    BlockDeviceError(BlockDevError),
+    FilesystemHierarchyError(FSHierarchyError),
+    FilesystemCopierError(FSCopierError),
+    InvalidFileStructureError(FileStructureError),
+}
+
+impl<BDE, FSHE, FSCE> From<FileStructureError> for WriteError<BDE, FSHE, FSCE> {
+    fn from(value: FileStructureError) -> Self {
+        Self::InvalidFileStructureError(value)
+    }
+}
+
+impl FileStructureError {
+    fn to_str(&self) -> &str {
+        match self {
+            Self::SerializationError(_) => "Serialization failed",
+            Self::StringEncodingError => "Cannot decode string into UTF-8",
+            Self::FileNameTooLong => "File name is too long",
+            Self::DuplicateFileName => "Duplicate file name",
+            Self::TooManyDirectoryEntries => "Too many entries in directory",
+            Self::FileTooLarge => "File is too large",
+        }
+    }
+}
+
+impl Display for FileStructureError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::SerializationError(ref e) => {
+                f.write_str("Serialization failed: ")?;
+                Display::fmt(e, f)
+            },
+            // FIXME: Encode context for other errors
+            other => f.write_str(other.to_str()),
+        }
+    }
+}
+
+impl Error for FileStructureError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::SerializationError(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl<BDE, FSHE, FSCE> WriteError<BDE, FSHE, FSCE> {
+    fn to_str(&self) -> &str {
+        match self {
+            Self::BlockDeviceError(_) => "Block device write failed",
+            Self::FilesystemHierarchyError(_) => "Filesystem hierarchy query failed",
+            Self::FilesystemCopierError(_) => "Filesystem to block device copy failed",
+            Self::InvalidFileStructureError(_) => "Failed to create XDVDFS filesystem",
+        }
+    }
+}
+
+impl<BDE: Display, FSHE: Display, FSCE: Display> Display for WriteError<BDE, FSHE, FSCE> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.to_str())?;
+        f.write_str(": ")?;
+
+        match self {
+            Self::BlockDeviceError(ref e) => Display::fmt(e, f),
+            Self::FilesystemHierarchyError(ref e) => Display::fmt(e, f),
+            Self::FilesystemCopierError(ref e) => Display::fmt(e, f),
+            Self::InvalidFileStructureError(ref e) => Display::fmt(e, f),
+        }
+    }
+}
+
+impl<BDE, FSHE, FSCE> Error for WriteError<BDE, FSHE, FSCE> 
+where
+    BDE: Display + Debug + Error + 'static,
+    FSHE: Display + Debug + Error + 'static,
+    FSCE: Display + Debug + Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::BlockDeviceError(ref e) => Some(e),
+            Self::FilesystemHierarchyError(ref e) => Some(e),
+            Self::FilesystemCopierError(ref e) => Some(e),
+            Self::InvalidFileStructureError(ref e) => Some(e),
+        }
+    }
+}

--- a/xdvdfs-core/src/write/mod.rs
+++ b/xdvdfs-core/src/write/mod.rs
@@ -53,7 +53,7 @@ impl Display for FileStructureError {
             Self::SerializationError(ref e) => {
                 f.write_str("Serialization failed: ")?;
                 Display::fmt(e, f)
-            },
+            }
             // FIXME: Encode context for other errors
             other => f.write_str(other.to_str()),
         }
@@ -94,7 +94,7 @@ impl<BDE: Display, FSHE: Display, FSCE: Display> Display for WriteError<BDE, FSH
     }
 }
 
-impl<BDE, FSHE, FSCE> Error for WriteError<BDE, FSHE, FSCE> 
+impl<BDE, FSHE, FSCE> Error for WriteError<BDE, FSHE, FSCE>
 where
     BDE: Display + Debug + Error + 'static,
     FSHE: Display + Debug + Error + 'static,

--- a/xdvdfs-desktop/Cargo.toml
+++ b/xdvdfs-desktop/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.3", features = [ "api-all"] }
 xdvdfs = { path = "../xdvdfs-core", version = "0.9.0" }
-ciso = { version = "0.2.0", default-features = false }
+ciso = { version = "0.3.0", default-features = false }
 maybe-async = "0.2.7"
 async-trait = "0.1.75"
 

--- a/xdvdfs-desktop/src/compress.rs
+++ b/xdvdfs-desktop/src/compress.rs
@@ -21,16 +21,12 @@ struct SplitStdFs;
 type BufFile = std::io::BufWriter<std::fs::File>;
 type BufFileSectorLinearFs<'a> = write::fs::SectorLinearBlockFilesystem<
     'a,
-    std::io::Error,
-    std::fs::File,
     write::fs::XDVDFSFilesystem<
-        std::io::Error,
-        blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>, std::io::Error>,
-        std::fs::File,
+        blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>>,
+        Box<[u8]>,
         write::fs::DefaultCopier<
-            std::io::Error,
-            blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>, std::io::Error>,
-            std::fs::File,
+            blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>>,
+            Box<[u8]>,
         >,
     >,
 >;
@@ -91,11 +87,8 @@ pub async fn compress_image(
     if meta.is_dir() {
         let mut fs = write::fs::StdFilesystem::create(&source_path);
         let mut slbd = write::fs::SectorLinearBlockDevice::default();
-        let mut slbfs: write::fs::SectorLinearBlockFilesystem<
-            std::io::Error,
-            std::fs::File,
-            write::fs::StdFilesystem,
-        > = write::fs::SectorLinearBlockFilesystem::new(&mut fs);
+        let mut slbfs: write::fs::SectorLinearBlockFilesystem<write::fs::StdFilesystem> =
+            write::fs::SectorLinearBlockFilesystem::new(&mut fs);
 
         write::img::create_xdvdfs_image(&mut slbfs, &mut slbd, progress_callback)
             .await

--- a/xdvdfs-desktop/src/compress.rs
+++ b/xdvdfs-desktop/src/compress.rs
@@ -23,11 +23,8 @@ type BufFileSectorLinearFs<'a> = write::fs::SectorLinearBlockFilesystem<
     'a,
     write::fs::XDVDFSFilesystem<
         blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>>,
-        Box<[u8]>,
-        write::fs::DefaultCopier<
-            blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>>,
-            Box<[u8]>,
-        >,
+        [u8],
+        write::fs::DefaultCopier<blockdev::OffsetWrapper<std::io::BufReader<std::fs::File>>, [u8]>,
     >,
 >;
 

--- a/xdvdfs-desktop/src/pack.rs
+++ b/xdvdfs-desktop/src/pack.rs
@@ -33,15 +33,13 @@ pub async fn pack_image(window: Window, source_path: String, dest_path: String) 
         let source = std::fs::File::options().read(true).open(source_path).ok()?;
         let source = std::io::BufReader::new(source);
         let source = xdvdfs::blockdev::OffsetWrapper::new(source).await.ok()?;
-        let mut fs = xdvdfs::write::fs::XDVDFSFilesystem::<
-            _,
-            _,
-            _,
-            xdvdfs::write::fs::StdIOCopier<_, _, _>,
-        >::new(source)
-        .await
-        .ok_or("Failed to create XDVDFS filesystem".to_string())
-        .ok()?;
+        let mut fs =
+            xdvdfs::write::fs::XDVDFSFilesystem::<_, _, xdvdfs::write::fs::StdIOCopier<_, _>>::new(
+                source,
+            )
+            .await
+            .ok_or("Failed to create XDVDFS filesystem".to_string())
+            .ok()?;
         xdvdfs::write::img::create_xdvdfs_image(&mut fs, &mut image, progress_callback)
             .await
             .ok()?;

--- a/xdvdfs-web/Cargo.toml
+++ b/xdvdfs-web/Cargo.toml
@@ -17,7 +17,7 @@ tauri = []
 [dependencies]
 async-recursion = "1.0.4"
 async-trait = "0.1.68"
-ciso = { version = "0.2.0", default-features = false }
+ciso = { version = "0.3.0", default-features = false }
 implicit-clone = "0.3.5"
 js-sys = "0.3.61"
 log = "0.4.17"

--- a/xdvdfs-web/src/fs/bindings.rs
+++ b/xdvdfs-web/src/fs/bindings.rs
@@ -83,6 +83,9 @@ extern "C" {
     #[wasm_bindgen(method, structural, js_class = "FileSystemWritableFileStream", js_name = write)]
     pub fn write_file(this: &FileSystemWritableFileStream, data: web_sys::File) -> js_sys::Promise;
 
+    #[wasm_bindgen(method, structural, js_class = "FileSystemWritableFileStream", js_name = write)]
+    pub fn write_blob(this: &FileSystemWritableFileStream, data: web_sys::Blob) -> js_sys::Promise;
+
     #[wasm_bindgen(method, structural, js_class = "FileSystemWritableFileStream", js_name = seek)]
     pub fn seek(this: &FileSystemWritableFileStream, position: f64) -> js_sys::Promise;
 }

--- a/xdvdfs-web/src/fs/ciso.rs
+++ b/xdvdfs-web/src/fs/ciso.rs
@@ -35,7 +35,9 @@ impl SplitFilesystem<String, FSWriteWrapper> for CisoOutputDirectory {
 }
 
 #[async_trait]
-impl AsyncWriter<String> for FSWriteWrapper {
+impl AsyncWriter for FSWriteWrapper {
+    type WriteError = String;
+
     async fn atomic_write(&mut self, position: u64, data: &[u8]) -> Result<(), String> {
         BlockDeviceWrite::write(self, position, data).await
     }

--- a/xdvdfs-web/src/fs/mod.rs
+++ b/xdvdfs-web/src/fs/mod.rs
@@ -197,13 +197,13 @@ impl xdvdfs::write::fs::FilesystemCopier<FSWriteWrapper> for WebFileSystem {
 }
 
 #[async_trait]
-impl xdvdfs::write::fs::FilesystemCopier<Box<[u8]>> for WebFileSystem {
+impl xdvdfs::write::fs::FilesystemCopier<[u8]> for WebFileSystem {
     type Error = String;
 
     async fn copy_file_in(
         &mut self,
         src: &PathVec,
-        dest: &mut Box<[u8]>,
+        dest: &mut [u8],
         offset: u64,
         size: u64,
     ) -> Result<u64, String> {

--- a/xdvdfs-web/src/fs/mod.rs
+++ b/xdvdfs-web/src/fs/mod.rs
@@ -32,7 +32,9 @@ impl FSWriteWrapper {
 }
 
 #[async_trait]
-impl xdvdfs::blockdev::BlockDeviceWrite<String> for FSWriteWrapper {
+impl xdvdfs::blockdev::BlockDeviceWrite for FSWriteWrapper {
+    type WriteError = String;
+
     async fn write(&mut self, offset: u64, buffer: &[u8]) -> Result<(), String> {
         UnsafeJSFuture::from(self.stream.seek(offset as f64))
             .await
@@ -55,7 +57,9 @@ impl xdvdfs::blockdev::BlockDeviceWrite<String> for FSWriteWrapper {
 }
 
 #[async_trait]
-impl xdvdfs::blockdev::BlockDeviceRead<String> for FileSystemFileHandle {
+impl xdvdfs::blockdev::BlockDeviceRead for FileSystemFileHandle {
+    type ReadError = String;
+
     async fn read(&mut self, offset: u64, buffer: &mut [u8]) -> Result<(), String> {
         let offset: f64 = offset as f64;
         let size: f64 = buffer.len() as u64 as f64;
@@ -120,7 +124,9 @@ unsafe impl Send for WebFileSystem {}
 unsafe impl Sync for WebFileSystem {}
 
 #[async_trait]
-impl xdvdfs::write::fs::Filesystem<FSWriteWrapper, String> for WebFileSystem {
+impl xdvdfs::write::fs::FilesystemHierarchy for WebFileSystem {
+    type Error = String;
+
     async fn read_dir(
         &mut self,
         dir: &PathVec,
@@ -153,6 +159,11 @@ impl xdvdfs::write::fs::Filesystem<FSWriteWrapper, String> for WebFileSystem {
 
         Ok(file_entries)
     }
+}
+
+#[async_trait]
+impl xdvdfs::write::fs::FilesystemCopier<FSWriteWrapper> for WebFileSystem {
+    type Error = String;
 
     async fn copy_file_in(
         &mut self,
@@ -183,14 +194,21 @@ impl xdvdfs::write::fs::Filesystem<FSWriteWrapper, String> for WebFileSystem {
             Err(String::from("Not a file"))
         }
     }
+}
 
-    async fn copy_file_buf(
+#[async_trait]
+impl xdvdfs::write::fs::FilesystemCopier<Box<[u8]>> for WebFileSystem {
+    type Error = String;
+
+    async fn copy_file_in(
         &mut self,
         src: &PathVec,
-        buf: &mut [u8],
+        dest: &mut Box<[u8]>,
         offset: u64,
+        size: u64,
     ) -> Result<u64, String> {
         let src_node = self.walk(src).ok_or("Failed to find src")?;
+        let size = core::cmp::min(size, dest.len() as u64);
         if let util::HandleType::File(ref src_fh) = src_node.handle {
             let offset = offset as f64;
             let slice = src_fh
@@ -199,7 +217,7 @@ impl xdvdfs::write::fs::Filesystem<FSWriteWrapper, String> for WebFileSystem {
                 .map_err(|_| "Failed to get file from handle")
                 .and_then(|file| {
                     let file_size = file.size() as u64;
-                    let size = core::cmp::min(file_size, buf.len() as u64);
+                    let size = core::cmp::min(file_size, size);
                     file.slice_with_f64_and_f64_and_content_type(
                         offset,
                         offset + size as f64,
@@ -215,14 +233,14 @@ impl xdvdfs::write::fs::Filesystem<FSWriteWrapper, String> for WebFileSystem {
             let slice_buf = js_sys::Uint8Array::new(&slice_buf);
 
             // Now that we have the slice, readjust expected copy size
-            let size = core::cmp::min(buf.len(), slice_buf.byte_length() as usize);
-            slice_buf.copy_to(&mut buf[0..size]);
+            let size = core::cmp::min(dest.len(), slice_buf.byte_length() as usize);
+            slice_buf.copy_to(&mut dest[0..size]);
 
-            if size != buf.len() {
-                buf[size..].fill(0);
+            if size != dest.len() {
+                dest[size..].fill(0);
             }
 
-            Ok(buf.len() as u64)
+            Ok(dest.len() as u64)
         } else {
             Err(String::from("Not a file"))
         }

--- a/xdvdfs-web/src/ops/browser.rs
+++ b/xdvdfs-web/src/ops/browser.rs
@@ -43,7 +43,7 @@ async fn pack_image_impl<T: Display, V: Display>(
 async fn compress_image_impl<
     T: Display,
     V: Display,
-    F: FilesystemHierarchy<Error = T> + FilesystemCopier<Box<[u8]>, Error = V>,
+    F: FilesystemHierarchy<Error = T> + FilesystemCopier<[u8], Error = V>,
 >(
     fs: &mut F,
     name: String,

--- a/xdvdfs-web/src/ops/mod.rs
+++ b/xdvdfs-web/src/ops/mod.rs
@@ -6,7 +6,7 @@ use crate::picker::{FilePickerBackend, PickerResult};
 #[cfg(not(feature = "tauri"))]
 pub mod browser;
 
-//#[cfg(feature = "tauri")]
+#[cfg(feature = "tauri")]
 pub mod tauri;
 
 #[async_trait(?Send)]


### PR DESCRIPTION
The Filesystem trait encompasses both reading filesystem metadata (i.e.
hierarchy) and copying data into block devices. The former does not
depend on the latter, and does not even require knowing any information
about the block device type, which makes extending the filesystem to
multiple devices difficult.

This is evident in the old design in `copy_file_buf`, which is
essentially a filesystem copier into a `&mut [u8]`. Since Filesystem
must supply both hierarchy and copying functions, this had to be
separate.

In the new design, filesystems need only implement FilesystemHierarchy,
and can implement as many FilesystemCopiers as needed for individual
block device types.

This also overhauls error handling to use associated types, cleaning up
signatures, and error enums keep better track of where the error
occurred (e.g. in the hierarchy vs copier, or in the block device).