### PR TITLE
cli: Add extract-xiso compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,12 +174,16 @@ $ xdvdfs unpack <path to image> [optional output path]
 
 | Command | Action |
 | - | - |
-| `xdvsfs ls <path to image> [path within image]` | Lists files within the specified directory, defaulting to root |
+| `xdvdfs ls <path to image> [path within image]` | Lists files within the specified directory, defaulting to root |
 | `xdvdfs tree <path to image>` | Prints a listing of every file within the image |
 | `xdvdfs md5 <path to image> [optional path to file within image]` | Prints md5 sums for specified files, or every file, within the image |
 | `xdvdfs checksum [path to img1]...` | Computes a checksum for all image contents to check integrity against other images |
 | `xdvdfs info <path to image> [path within image]` | Prints metadata info for the specified directory entry, or root volume |
 | `xdvdfs copy-out <path to image> <path within image> <destination path>` | Copies a single file or directory out of the provided image |
+
+xdvdfs-cli can be run in an extract-xiso (best-effort) compatibility mode by renaming (or symlinking) the executable
+to be named `extract-xiso`. The command-line interface then mimics extract-xiso's parameters. Only basic use cases
+(i.e. `-xlrc` modes and `-dD` options) are supported, and most options are no-ops.
 
 ## xdvdfs-core
 

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -24,9 +24,9 @@ def run_cmd_with_io(cmd, input, output, options = ''):
     if proc.returncode != 0:
         raise Exception('Failed to run command')
 
-def test_pack_unpack(dir, output_img, args):
+def test_pack_unpack(dir, output_img, unpack_cmd):
     output_dir = tempfile.TemporaryDirectory()
-    run_cmd_with_io(args.unpack_cmd, output_img.name, output_dir.name)
+    run_cmd_with_io(unpack_cmd, output_img.name, output_dir.name)
 
     l1_cmp = filecmp.dircmp(dir, output_dir.name)
     if l1_cmp.diff_files or l1_cmp.left_only or l1_cmp.right_only or l1_cmp.funny_files:
@@ -52,7 +52,7 @@ class PackTestCase(TestCase):
         img_file = tempfile.NamedTemporaryFile()
         run_cmd_with_io(args.pack_cmd, dir, img_file.name)
 
-        test_pack_unpack(dir, img_file, args)
+        test_pack_unpack(dir, img_file, args.unpack_cmd)
         test_repack_unpack(dir, img_file, args)
 
 class BuildImageTestCase(TestCase):
@@ -68,10 +68,10 @@ class BuildImageTestCase(TestCase):
         # Pass through the build_image_opts first
         img_file = tempfile.NamedTemporaryFile()
         run_cmd_with_io(CMD_BUILD_IMAGE, dir + '/source', img_file.name, self._build_image_opts)
-        test_pack_unpack(dir + '/dest', img_file, args)
+        test_pack_unpack(dir + '/dest', img_file, args.unpack_cmd)
 
         # Create an xdvdfs.toml file and build the image from config
         img_file2 = tempfile.NamedTemporaryFile()
         run_cmd_with_io(CMD_IMAGE_SPEC, None, dir + '/source/xdvdfs.toml', self._build_image_opts)
         run_cmd_with_io(CMD_BUILD_IMAGE, dir + '/source', img_file2.name)
-        test_pack_unpack(dir + '/dest', img_file2, args)
+        test_pack_unpack(dir + '/dest', img_file2, args.unpack_cmd)

--- a/xdvdfs-cli/README.md
+++ b/xdvdfs-cli/README.md
@@ -168,7 +168,7 @@ $ xdvdfs unpack <path to image> [optional output path]
 
 | Command | Action |
 | - | - |
-| `xdvsfs ls <path to image> [path within image]` | Lists files within the specified directory, defaulting to root |
+| `xdvdfs ls <path to image> [path within image]` | Lists files within the specified directory, defaulting to root |
 | `xdvdfs tree <path to image>` | Prints a listing of every file within the image |
 | `xdvdfs md5 <path to image> [optional path to file within image]` | Prints md5 sums for specified files, or every file, within the image |
 | `xdvdfs checksum [path to img1]...` | Computes a checksum for all image contents to check integrity against other images |

--- a/xdvdfs-cli/src/cmd_read.rs
+++ b/xdvdfs-cli/src/cmd_read.rs
@@ -63,7 +63,7 @@ pub async fn cmd_ls(args: &LsArgs) -> Result<(), anyhow::Error> {
 #[command(about = "List all files in an image, recursively")]
 pub struct TreeArgs {
     #[arg(help = "Path to XISO image")]
-    image_path: String,
+    pub image_path: String,
 }
 
 #[maybe_async]
@@ -89,7 +89,10 @@ pub async fn cmd_tree(args: &TreeArgs) -> Result<(), anyhow::Error> {
         }
     }
 
-    println!("{} files, {} bytes", file_count, total_size);
+    println!(
+        "{} files, {} bytes in {}",
+        file_count, total_size, args.image_path
+    );
 
     Ok(())
 }

--- a/xdvdfs-cli/src/cmd_unpack.rs
+++ b/xdvdfs-cli/src/cmd_unpack.rs
@@ -74,10 +74,10 @@ async fn copyout_directory(
 #[command(about = "Unpack an entire image to a directory")]
 pub struct UnpackArgs {
     #[arg(help = "Path to XISO image")]
-    image_path: String,
+    pub image_path: String,
 
     #[arg(help = "Output directory")]
-    path: Option<String>,
+    pub path: Option<String>,
 }
 
 #[maybe_async]

--- a/xdvdfs-cli/src/executor.rs
+++ b/xdvdfs-cli/src/executor.rs
@@ -1,0 +1,15 @@
+#[cfg(feature = "sync")]
+macro_rules! run_with_executor {
+    ($f:ident, $($x:expr),*) => {
+        $f($($x),*)
+    };
+}
+
+#[cfg(not(feature = "sync"))]
+macro_rules! run_with_executor {
+    ($f:ident, $($x:expr),*) => {
+        futures::executor::block_on($f($($x),*))
+    };
+}
+
+pub(crate) use run_with_executor;

--- a/xdvdfs-cli/src/exiso_compat.rs
+++ b/xdvdfs-cli/src/exiso_compat.rs
@@ -1,0 +1,214 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::bail;
+use clap::{ArgAction, Parser, Subcommand};
+use maybe_async::maybe_async;
+
+use crate::img::{absolute_path, with_extension};
+
+#[derive(Subcommand)]
+#[command(
+    subcommand_help_heading = "Mode",
+    subcommand_value_name = "MODE",
+    disable_help_subcommand = true
+)]
+pub enum EXMode {
+    #[command(
+        short_flag = 'c',
+        override_usage = "-c <DIR> [FILE] [-c <DIR> [FILE]]...",
+        about = "Create XISO file from <DIR>, at [FILE]. Can be specified multiple times"
+    )]
+    C {
+        dir: String,
+        file: Option<String>,
+
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        rest: Vec<String>,
+    },
+
+    #[command(short_flag = 'l', about = "List files inside given XISO images")]
+    L { xiso: Vec<String> },
+
+    #[command(short_flag = 'x', about = "Extract XISO (default mode if none given)")]
+    X { xiso: Vec<String> },
+
+    #[command(short_flag = 'r', about = "Rewrite XISO, moving input to <FILE>.old")]
+    R { xiso: Vec<String> },
+
+    #[command(external_subcommand)]
+    None(Vec<String>),
+}
+
+#[derive(Parser)]
+#[command(
+    disable_version_flag = true,
+    version = concat!("(extract-xiso compatibility mode) ", env!("CARGO_PKG_VERSION")),
+)]
+pub struct EXCommand {
+    #[arg(
+        short = 'd',
+        help = "In extract mode, expand in directory.\nIn rewrite mode, output xiso in directory."
+    )]
+    directory: Option<String>,
+
+    #[arg(short = 'D', help = "In rewrite mode, delete the original image")]
+    delete: bool,
+
+    #[arg(short = 'm', help = "No-op placeholder for compatibility")]
+    flag_m: bool,
+
+    #[arg(short = 'q', help = "Silence error output (unimplemented)")]
+    quiet_error: bool,
+
+    #[arg(short = 'Q', help = "Silence all output (unimplemented)")]
+    quiet_all: bool,
+
+    #[arg(short = 's', help = "No-op placeholder for compatibility")]
+    flag_s: bool,
+
+    #[arg(
+        short = 'v',
+        action = ArgAction::Version,
+        help = "Print version",
+    )]
+    v: (),
+
+    #[command(subcommand)]
+    mode: EXMode,
+}
+
+async fn exiso_create_single(dir: &String, file: &Option<String>) -> anyhow::Result<()> {
+    let dir = absolute_path(Path::new(dir))?;
+    let meta = std::fs::metadata(&dir)?;
+    if !meta.is_dir() {
+        bail!("Input is not a directory");
+    }
+
+    let image_path = file
+        .as_ref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dir.with_extension("iso"));
+
+    use crate::cmd_pack::*;
+    cmd_pack_path(&dir, &image_path).await
+}
+
+#[maybe_async]
+async fn exiso_create(dir: &String, file: &Option<String>, rest: &[String]) -> anyhow::Result<()> {
+    let mut tasks = Vec::new();
+    tasks.push((dir, file.clone()));
+
+    let mut i = 0;
+    while i < rest.len() {
+        if rest[i] != "-c" {
+            bail!(
+                "Create arg in position {} must begin with `-c`",
+                tasks.len() + 1
+            );
+        }
+
+        if i + 1 >= rest.len() {
+            bail!(
+                "Create arg in position {} is missing dir name",
+                tasks.len() + 1
+            );
+        }
+
+        if i + 2 < rest.len() && rest[i + 2] != "-c" {
+            tasks.push((&rest[i + 1], Some(rest[i + 2].clone())));
+            i += 2;
+        } else {
+            tasks.push((&rest[i + 1], None));
+            i += 2;
+        }
+    }
+
+    for (dir, file) in tasks {
+        exiso_create_single(dir, &file).await?;
+    }
+
+    Ok(())
+}
+
+async fn exiso_list(xiso_list: &Vec<String>) -> anyhow::Result<()> {
+    use crate::cmd_read::{cmd_tree, TreeArgs};
+    for xiso in xiso_list {
+        cmd_tree(&TreeArgs {
+            image_path: xiso.clone(),
+        })
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn exiso_extract(xiso_list: &Vec<String>, directory: &Option<String>) -> anyhow::Result<()> {
+    use crate::cmd_unpack::{cmd_unpack, UnpackArgs};
+    for xiso in xiso_list {
+        cmd_unpack(&UnpackArgs {
+            image_path: xiso.clone(),
+            path: directory.clone(),
+        })
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn exiso_repack(
+    xiso_list: &Vec<String>,
+    directory: &Option<String>,
+    delete: bool,
+) -> anyhow::Result<()> {
+    use crate::cmd_pack::cmd_pack_path;
+
+    for xiso in xiso_list {
+        let source_path = absolute_path(Path::new(&xiso))?;
+        let metadata = std::fs::metadata(&source_path)?;
+        if !metadata.is_file() {
+            bail!("Repack input must be a file");
+        }
+
+        // Move input to `input.old`
+        let renamed_input_path = with_extension(&source_path, "old", false);
+        std::fs::rename(&source_path, &renamed_input_path)?;
+
+        // Pack using `input.old` as input, and source path as output
+        let dest_path = match directory {
+            Some(d) => {
+                absolute_path(Path::new(d))?.with_file_name(source_path.file_name().unwrap())
+            }
+            None => source_path,
+        };
+
+        cmd_pack_path(&renamed_input_path, &dest_path).await?;
+
+        if delete {
+            std::fs::remove_file(&renamed_input_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[maybe_async]
+pub async fn run_exiso_command(cmd: &EXCommand) -> anyhow::Result<()> {
+    // FIXME: Respect -q and -Q during processing
+    match &cmd.mode {
+        EXMode::C { dir, file, rest } => exiso_create(dir, file, rest).await,
+        EXMode::L { xiso } => exiso_list(xiso).await,
+        EXMode::X { xiso } | EXMode::None(xiso) => exiso_extract(xiso, &cmd.directory).await,
+        EXMode::R { xiso } => exiso_repack(xiso, &cmd.directory, cmd.delete).await,
+    }
+}
+
+pub fn run_exiso_program(cmd: &EXCommand) {
+    let res = crate::executor::run_with_executor!(run_exiso_command, cmd);
+    if let Err(err) = res {
+        if !cmd.quiet_error && !cmd.quiet_all {
+            eprintln!("error: {err}");
+        }
+
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
Adds an extract-xiso compatibility frontend for the CLI, available by symlinking/renaming the binary to `extract-xiso`, or alternatively using the hidden `xdvdfs extract-xiso` subcommand for development.

Fixes #9 