### PR TITLE
Show image type in info subcommand, introduce XGD offsets enum

### DIFF
--- a/xdvdfs-web/src/ops/browser.rs
+++ b/xdvdfs-web/src/ops/browser.rs
@@ -122,7 +122,7 @@ impl XDVDFSOperations<WebFSBackend> for WebXDVDFSOps {
         let src_file = src.to_file().await?;
         let mut img = xdvdfs::blockdev::OffsetWrapper::new(src).await?;
         let volume = xdvdfs::read::read_volume(&mut img).await?;
-        let img_offset = img.get_offset() as f64;
+        let img_offset = u64::from(img.get_offset()) as f64;
 
         let mut stack: Vec<(FileSystemDirectoryHandle, DirectoryEntryNode)> = Vec::new();
         for entry in volume.root_table.walk_dirent_tree(&mut img).await? {


### PR DESCRIPTION
Seeks to resolve #121 by printing the image XGD type and its offset. This is achieved by implementing a new `XDVDFSOffsets` enum that replaces `XDVD_OFFSETS`.