### PR TITLE
core: Disable clippy manual_is_multiple_of lint

### DIFF
--- a/xdvdfs-core/src/lib.rs
+++ b/xdvdfs-core/src/lib.rs
@@ -1,4 +1,9 @@
 #![no_std]
+// TODO: Re-enable and fix lint once Nix stable build is fixed
+// `is_multiple_of` is too new (Rust 1.87) and the lint is added
+// in 1.89, neither of which are in Nix stable currently
+#![allow(unknown_lints)]
+#![allow(clippy::manual_is_multiple_of)]
 
 extern crate alloc;
 #[cfg(feature = "std")]


### PR DESCRIPTION
This lint suggests a function that is new in Rust 1.87, which is not yet available on Nix stable.