### PR TITLE
core: Add in-memory filesystem and create path submodule

### DIFF
--- a/xdvdfs-core/src/write/fs/memory.rs
+++ b/xdvdfs-core/src/write/fs/memory.rs
@@ -1,0 +1,351 @@
+use alloc::vec::Vec;
+use maybe_async::maybe_async;
+
+#[cfg(not(feature = "sync"))]
+use alloc::boxed::Box;
+
+use crate::write::fs::{
+    path::{PathPrefixTree, PathRef},
+    FileEntry, FileType, FilesystemCopier, FilesystemHierarchy, PathVec,
+};
+
+#[derive(Default, Debug, Clone)]
+struct Entry {
+    data: Option<Vec<u8>>,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct MemoryFilesystem(PathPrefixTree<Entry>);
+
+impl MemoryFilesystem {
+    pub fn mkdir<'a, P: Into<PathRef<'a>>>(&mut self, path: P) {
+        let mut node = &mut self.0;
+
+        for component in path.into() {
+            node = node.insert_tail(component, Entry { data: None })
+        }
+    }
+
+    pub fn touch<'a, P: Into<PathRef<'a>>>(&mut self, path: P) {
+        self.create(path, &[]);
+    }
+
+    pub fn create<'a, P: Into<PathRef<'a>>>(&mut self, path: P, data: &[u8]) {
+        let mut node = &mut self.0;
+        let mut iter = path.into().peekable();
+
+        while let Some(component) = iter.next() {
+            let data = match iter.peek() {
+                Some(_) => None,
+                None => Some(data.to_vec()),
+            };
+
+            node = node.insert_tail(component, Entry { data })
+        }
+    }
+
+    pub fn lsdir<'a, P: Into<PathRef<'a>>>(&self, path: P) -> Option<Vec<FileEntry>> {
+        let dir = self.0.lookup_subdir(path)?;
+        let entries: Vec<FileEntry> = dir
+            .iter()
+            .map(|(name, entry)| FileEntry {
+                name,
+                file_type: match entry.data {
+                    Some(_) => FileType::File,
+                    None => FileType::Directory,
+                },
+                len: entry.data.as_ref().map(|d| d.len() as u64).unwrap_or(0),
+            })
+            .collect();
+        Some(entries)
+    }
+
+    pub fn read<'a, P: Into<PathRef<'a>>>(
+        &self,
+        path: P,
+        offset: usize,
+        buffer: &mut [u8],
+    ) -> Option<usize> {
+        let file = self.0.get(path)?.data.as_ref()?;
+        if offset >= file.len() {
+            return None;
+        }
+
+        let size = core::cmp::min(buffer.len(), file.len() - offset);
+        let limit = offset + size;
+        assert!(limit <= file.len());
+
+        buffer[0..size].copy_from_slice(&file[offset..limit]);
+        Some(size)
+    }
+
+    // Split out impl into sync function for testing
+    fn copy_file_in_impl<'a, P: Into<PathRef<'a>>>(
+        &self,
+        src: P,
+        dest: &mut [u8],
+        input_offset: u64,
+        output_offset: u64,
+        size: u64,
+    ) -> Result<u64, ()> {
+        let input_offset = input_offset as usize;
+        let output_offset = output_offset as usize;
+
+        if dest.len() <= output_offset {
+            return Err(());
+        }
+        let limit = core::cmp::min(dest.len(), output_offset + (size as usize));
+        assert!(limit >= output_offset);
+
+        let buffer = &mut dest[output_offset..limit];
+        let bytes_read = self.read(src, input_offset, buffer).ok_or(())?;
+        dest[(output_offset + bytes_read)..limit].fill(0);
+        Ok((limit - output_offset) as u64)
+    }
+}
+
+#[maybe_async]
+impl FilesystemHierarchy for MemoryFilesystem {
+    type Error = ();
+
+    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, ()> {
+        self.lsdir(path).ok_or(())
+    }
+}
+
+#[maybe_async]
+impl FilesystemCopier<[u8]> for MemoryFilesystem {
+    type Error = ();
+
+    async fn copy_file_in(
+        &mut self,
+        src: &PathVec,
+        dest: &mut [u8],
+        input_offset: u64,
+        output_offset: u64,
+        size: u64,
+    ) -> Result<u64, ()> {
+        self.copy_file_in_impl(src, dest, input_offset, output_offset, size)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::string::ToString;
+
+    use crate::write::fs::{FileEntry, FileType, MemoryFilesystem};
+
+    #[test]
+    fn test_memfs_lsdir_no_entry() {
+        let memfs = MemoryFilesystem::default();
+        assert_eq!(memfs.lsdir("/a"), None);
+    }
+
+    #[test]
+    fn test_memfs_mkdir() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.mkdir("/a/b");
+        memfs.mkdir("/a/c");
+
+        let entries = memfs.lsdir("/a").expect("'/a' should contain records");
+        assert_eq!(
+            entries,
+            [
+                FileEntry {
+                    name: "b".to_string(),
+                    file_type: FileType::Directory,
+                    len: 0,
+                },
+                FileEntry {
+                    name: "c".to_string(),
+                    file_type: FileType::Directory,
+                    len: 0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_memfs_create() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.create("/a/b", &[0, 1, 2]);
+        memfs.create("/a/c", &[3, 4]);
+
+        let entries = memfs.lsdir("/a").expect("'/a' should contain records");
+        assert_eq!(
+            entries,
+            [
+                FileEntry {
+                    name: "b".to_string(),
+                    file_type: FileType::File,
+                    len: 3,
+                },
+                FileEntry {
+                    name: "c".to_string(),
+                    file_type: FileType::File,
+                    len: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_memfs_touch() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.touch("/a/b");
+        memfs.touch("/a/c");
+
+        let entries = memfs.lsdir("/a").expect("'/a' should contain records");
+        assert_eq!(
+            entries,
+            [
+                FileEntry {
+                    name: "b".to_string(),
+                    file_type: FileType::File,
+                    len: 0,
+                },
+                FileEntry {
+                    name: "c".to_string(),
+                    file_type: FileType::File,
+                    len: 0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_memfs_mixed_files_and_dirs() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.touch("/a/b");
+        memfs.mkdir("/a/c");
+        memfs.create("a/d", &[1]);
+
+        let entries = memfs.lsdir("/a").expect("'/a' should contain records");
+        assert_eq!(
+            entries,
+            [
+                FileEntry {
+                    name: "b".to_string(),
+                    file_type: FileType::File,
+                    len: 0,
+                },
+                FileEntry {
+                    name: "c".to_string(),
+                    file_type: FileType::Directory,
+                    len: 0,
+                },
+                FileEntry {
+                    name: "d".to_string(),
+                    file_type: FileType::File,
+                    len: 1,
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_memfs_read_no_entry() {
+        let memfs = MemoryFilesystem::default();
+        let mut buf = [0; 5];
+        assert_eq!(memfs.read("/a", 0, &mut buf), None);
+    }
+
+    #[test]
+    fn test_memfs_read_file_full() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.create("/a/b", &[1, 2, 3, 4, 5]);
+
+        let mut buf = [0; 5];
+        assert_eq!(memfs.read("/a/b", 0, &mut buf), Some(5));
+        assert_eq!(buf, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_memfs_read_file_offset() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.create("/a/b", &[1, 2, 3, 4, 5]);
+
+        let mut buf = [0; 5];
+        assert_eq!(memfs.read("/a/b", 2, &mut buf), Some(3));
+        assert_eq!(buf, [3, 4, 5, 0, 0]);
+    }
+
+    #[test]
+    fn test_memfs_read_file_invalid_offset() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.create("/a/b", &[1, 2, 3, 4, 5]);
+
+        let mut buf = [0; 5];
+        assert_eq!(memfs.read("/a/b", 6, &mut buf), None);
+    }
+
+    #[test]
+    fn test_memfs_read_directory_fails() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.mkdir("/a/b");
+
+        let mut buf = [0; 5];
+        assert_eq!(memfs.read("/a/b", 2, &mut buf), None);
+    }
+
+    #[test]
+    fn test_memfs_copy_file_in() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.create("/a/b", &[1, 2, 3, 4, 5]);
+
+        let mut buf = [0; 5];
+        assert_eq!(memfs.copy_file_in_impl("/a/b", &mut buf, 0, 0, 5), Ok(5));
+        assert_eq!(buf, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_memfs_copy_file_in_output_offset() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.create("/a/b", &[1, 2, 3, 4, 5]);
+
+        // Read past end of file, extra space filled with 0
+        let mut buf = [10; 9];
+        assert_eq!(memfs.copy_file_in_impl("/a/b", &mut buf, 0, 2, 7), Ok(7));
+        assert_eq!(buf, [10, 10, 1, 2, 3, 4, 5, 0, 0]);
+    }
+
+    #[test]
+    fn test_memfs_copy_file_in_invalid_output_offset() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.create("/a/b", &[1, 2, 3, 4, 5]);
+
+        let mut buf = [0; 5];
+        assert_eq!(memfs.copy_file_in_impl("/a/b", &mut buf, 0, 6, 5), Err(()));
+    }
+
+    #[test]
+    fn test_memfs_copy_file_in_buffer_size_clamped() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.create("/a/b", &[1, 2, 3, 4, 5]);
+
+        // Output offset by 2, input offset by 0, data after EOF is filled 0
+        let mut buf = [10; 8];
+        assert_eq!(memfs.copy_file_in_impl("/a/b", &mut buf, 0, 2, 7), Ok(6));
+        assert_eq!(buf, [10, 10, 1, 2, 3, 4, 5, 0]);
+    }
+
+    #[test]
+    fn test_memfs_copy_file_in_input_offset() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.create("/a/b", &[1, 2, 3, 4, 5]);
+
+        // Read is offset by 2, data after EOF is filled 0
+        let mut buf = [1; 5];
+        assert_eq!(memfs.copy_file_in_impl("/a/b", &mut buf, 2, 0, 5), Ok(5));
+        assert_eq!(buf, [3, 4, 5, 0, 0]);
+    }
+
+    #[test]
+    fn test_memfs_copy_file_in_invalid_input_offset() {
+        let mut memfs = MemoryFilesystem::default();
+        memfs.create("/a/b", &[1, 2, 3, 4, 5]);
+
+        let mut buf = [0; 5];
+        assert_eq!(memfs.copy_file_in_impl("/a/b", &mut buf, 5, 0, 5), Err(()));
+    }
+}

--- a/xdvdfs-core/src/write/fs/mod.rs
+++ b/xdvdfs-core/src/write/fs/mod.rs
@@ -1,21 +1,22 @@
-use core::fmt::Debug;
-use core::slice::Iter;
-use std::borrow::ToOwned;
-use std::format;
-use std::path::{Path, PathBuf};
-
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
+
+use core::fmt::Debug;
 
 use crate::blockdev::BlockDeviceWrite;
 
 use maybe_async::maybe_async;
 
+mod memory;
 mod remap;
 mod sector_linear;
 mod xdvdfs;
 
+pub mod path;
+pub use path::*;
+
+pub use memory::*;
 pub use remap::*;
 pub use sector_linear::*;
 pub use xdvdfs::*;
@@ -26,20 +27,13 @@ mod stdfs;
 #[cfg(not(target_family = "wasm"))]
 pub use stdfs::*;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FileType {
     File,
     Directory,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct PathVec {
-    components: Vec<String>,
-}
-
-type PathVecIter<'a> = Iter<'a, String>;
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FileEntry {
     pub name: String,
     pub file_type: FileType,
@@ -50,69 +44,6 @@ pub struct FileEntry {
 pub struct DirectoryTreeEntry {
     pub dir: PathVec,
     pub listing: Vec<FileEntry>,
-}
-
-impl PathVec {
-    pub fn as_path_buf(&self, prefix: &Path) -> PathBuf {
-        let suffix = PathBuf::from_iter(self.components.iter());
-        prefix.join(suffix)
-    }
-
-    pub fn is_root(&self) -> bool {
-        self.components.is_empty()
-    }
-
-    pub fn iter(&self) -> PathVecIter<'_> {
-        self.components.iter()
-    }
-
-    pub fn from_base(prefix: &Self, suffix: &str) -> Self {
-        let mut path = prefix.clone();
-        path.components.push(suffix.to_owned());
-        path
-    }
-
-    pub fn as_string(&self) -> String {
-        format!("/{}", self.components.join("/"))
-    }
-
-    pub fn base(&self) -> PathVec {
-        PathVec {
-            components: self.components[0..self.components.len() - 1].to_vec(),
-        }
-    }
-
-    pub fn suffix(&self, prefix: &Self) -> Self {
-        let mut components = Vec::new();
-        let mut i1 = self.iter();
-        let mut i2 = prefix.iter();
-
-        loop {
-            let c1 = i1.next();
-            let c2 = i2.next();
-
-            if let Some(component) = c1 {
-                if let Some(component2) = c2 {
-                    assert_eq!(component, component2);
-                } else {
-                    components.push(component.clone());
-                }
-            } else {
-                return Self { components };
-            }
-        }
-    }
-}
-
-impl<'a> FromIterator<&'a str> for PathVec {
-    fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
-        let components = iter
-            .into_iter()
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_owned())
-            .collect();
-        Self { components }
-    }
 }
 
 /// A trait for filesystem hierarchies, representing any filesystem
@@ -185,134 +116,24 @@ impl<E, BDW: BlockDeviceWrite> FilesystemCopier<BDW> for Box<dyn FilesystemCopie
     }
 }
 
-#[derive(Clone, Debug)]
-struct PathPrefixTree<T> {
-    children: [Option<Box<PathPrefixTree<T>>>; 256],
-    pub record: Option<(T, Box<PathPrefixTree<T>>)>,
-}
+#[maybe_async]
+impl<E, BDW, F> FilesystemCopier<BDW> for &mut F
+where
+    BDW: BlockDeviceWrite + ?Sized,
+    F: FilesystemCopier<BDW, Error = E> + ?Sized,
+{
+    type Error = E;
 
-struct PPTIter<'a, T> {
-    queue: Vec<(String, &'a PathPrefixTree<T>)>,
-}
-
-impl<'a, T> Iterator for PPTIter<'a, T> {
-    type Item = (String, &'a T);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        use alloc::borrow::ToOwned;
-
-        // Expand until we find a node with a record
-        while let Some(subtree) = self.queue.pop() {
-            let (name, node) = &subtree;
-            for (ch, child) in node.children.iter().enumerate() {
-                if let Some(child) = child {
-                    let mut name = name.to_owned();
-                    name.push(ch as u8 as char);
-                    self.queue.push((name, child));
-                }
-            }
-
-            if let Some(record) = &node.record {
-                return Some((name.to_owned(), &record.0));
-            }
-        }
-
-        None
-    }
-}
-
-impl<T> Default for PathPrefixTree<T> {
-    fn default() -> Self {
-        Self {
-            children: [const { None }; 256],
-            record: None,
-        }
-    }
-}
-
-impl<T> PathPrefixTree<T> {
-    /// Looks up a node, only descending into subdirs if the path is not consumed
-    pub fn lookup_node(&self, path: &PathVec) -> Option<&Self> {
-        let mut node = self;
-
-        let mut component_iter = path.iter().peekable();
-        while let Some(component) = component_iter.next() {
-            for ch in component.chars() {
-                let next = &node.children[ch as usize];
-                node = next.as_ref()?;
-            }
-
-            if component_iter.peek().is_some() {
-                let record = &node.record;
-                let (_, subtree) = record.as_ref()?;
-                node = subtree;
-            }
-        }
-
-        Some(node)
-    }
-
-    /// Looks up a node, only descending into subdirs if the path is not consumed
-    pub fn lookup_node_mut(&mut self, path: &PathVec) -> Option<&mut Self> {
-        let mut node = self;
-
-        let mut component_iter = path.iter().peekable();
-        while let Some(component) = component_iter.next() {
-            for ch in component.chars() {
-                let next = &mut node.children[ch as usize];
-                node = next.as_mut()?;
-            }
-
-            if component_iter.peek().is_some() {
-                let record = &mut node.record;
-                let (_, subtree) = record.as_mut()?;
-                node = subtree;
-            }
-        }
-
-        Some(node)
-    }
-
-    /// Looks up a subdir, returning its subtree
-    pub fn lookup_subdir(&self, path: &PathVec) -> Option<&Self> {
-        let mut node = self;
-
-        for component in path.iter() {
-            for ch in component.chars() {
-                let next = &node.children[ch as usize];
-                node = next.as_ref()?;
-            }
-
-            let record = &node.record;
-            let (_, subtree) = record.as_ref()?;
-            node = subtree;
-        }
-
-        Some(node)
-    }
-
-    pub fn insert_tail(&mut self, tail: &str, val: T) -> &mut Self {
-        let mut node = self;
-
-        for ch in tail.chars() {
-            let next = &mut node.children[ch as usize];
-            node = next.get_or_insert_with(|| Box::new(Self::default()));
-        }
-
-        node.record
-            .get_or_insert_with(|| (val, Box::new(Self::default())))
-            .1
-            .as_mut()
-    }
-
-    pub fn get(&self, path: &PathVec) -> Option<&T> {
-        let node = self.lookup_node(path)?;
-        node.record.as_ref().map(|v| &v.0)
-    }
-
-    pub fn iter(&self) -> PPTIter<'_, T> {
-        PPTIter {
-            queue: alloc::vec![(String::new(), self)],
-        }
+    async fn copy_file_in(
+        &mut self,
+        src: &PathVec,
+        dest: &mut BDW,
+        input_offset: u64,
+        output_offset: u64,
+        size: u64,
+    ) -> Result<u64, E> {
+        (**self)
+            .copy_file_in(src, dest, input_offset, output_offset, size)
+            .await
     }
 }

--- a/xdvdfs-core/src/write/fs/path/mod.rs
+++ b/xdvdfs-core/src/write/fs/path/mod.rs
@@ -1,0 +1,10 @@
+mod pathvec;
+pub use pathvec::PathVec;
+pub use pathvec::PathVecIter;
+
+mod pathref;
+pub use pathref::PathRef;
+
+mod pathtrie;
+pub use pathtrie::PPTIter;
+pub use pathtrie::PathPrefixTree;

--- a/xdvdfs-core/src/write/fs/path/pathref.rs
+++ b/xdvdfs-core/src/write/fs/path/pathref.rs
@@ -1,0 +1,38 @@
+use alloc::boxed::Box;
+
+pub struct PathRef<'a>(Box<dyn Iterator<Item = &'a str> + 'a>);
+
+impl PathRef<'_> {
+    pub fn new<'a, I: Iterator<Item = &'a str> + 'a>(iter: I) -> PathRef<'a> {
+        PathRef(Box::new(iter))
+    }
+}
+
+impl<'a> From<&'a str> for PathRef<'a> {
+    fn from(value: &'a str) -> Self {
+        PathRef::new(value.split("/").filter(|component| !component.is_empty()))
+    }
+}
+
+impl<'a> Iterator for PathRef<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_str_to_pathref_components() {
+        use alloc::borrow::ToOwned;
+
+        let path = "/hello/world/";
+        let path: super::PathRef<'_> = path.into();
+        let components: alloc::vec::Vec<alloc::string::String> =
+            path.map(|component| component.to_owned()).collect();
+
+        assert_eq!(components, &["hello", "world",]);
+    }
+}

--- a/xdvdfs-core/src/write/fs/path/pathtrie.rs
+++ b/xdvdfs-core/src/write/fs/path/pathtrie.rs
@@ -1,0 +1,325 @@
+use alloc::boxed::Box;
+use alloc::collections::VecDeque;
+use alloc::string::String;
+
+use crate::write::fs::PathRef;
+
+#[derive(Clone, Debug)]
+pub struct PathPrefixTree<T> {
+    children: [Option<Box<PathPrefixTree<T>>>; 256],
+    pub record: Option<(T, Box<PathPrefixTree<T>>)>,
+}
+
+pub struct PPTIter<'a, T> {
+    queue: VecDeque<(String, &'a PathPrefixTree<T>)>,
+}
+
+impl<'a, T> Iterator for PPTIter<'a, T> {
+    type Item = (String, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use alloc::borrow::ToOwned;
+
+        // Expand until we find a node with a record
+        while let Some(subtree) = self.queue.pop_front() {
+            let (name, node) = &subtree;
+            for (ch, child) in node.children.iter().enumerate() {
+                if let Some(child) = child {
+                    let mut name = name.to_owned();
+                    name.push(ch as u8 as char);
+                    self.queue.push_back((name, child));
+                }
+            }
+
+            if let Some(record) = &node.record {
+                return Some((name.to_owned(), &record.0));
+            }
+        }
+
+        None
+    }
+}
+
+impl<T> Default for PathPrefixTree<T> {
+    fn default() -> Self {
+        Self {
+            children: [const { None }; 256],
+            record: None,
+        }
+    }
+}
+
+impl<T> PathPrefixTree<T> {
+    /// Looks up a node, only descending into subdirs if the path is not consumed
+    pub fn lookup_node<'a, P: Into<PathRef<'a>>>(&self, path: P) -> Option<&Self> {
+        let mut node = self;
+
+        let mut component_iter = path.into().peekable();
+        while let Some(component) = component_iter.next() {
+            for ch in component.chars() {
+                let next = &node.children[ch as usize];
+                node = next.as_ref()?;
+            }
+
+            if component_iter.peek().is_some() {
+                let record = &node.record;
+                let (_, subtree) = record.as_ref()?;
+                node = subtree;
+            }
+        }
+
+        Some(node)
+    }
+
+    /// Looks up a node, only descending into subdirs if the path is not consumed
+    pub fn lookup_node_mut<'a, P: Into<PathRef<'a>>>(&mut self, path: P) -> Option<&mut Self> {
+        let mut node = self;
+
+        let mut component_iter = path.into().peekable();
+        while let Some(component) = component_iter.next() {
+            for ch in component.chars() {
+                let next = &mut node.children[ch as usize];
+                node = next.as_mut()?;
+            }
+
+            if component_iter.peek().is_some() {
+                let record = &mut node.record;
+                let (_, subtree) = record.as_mut()?;
+                node = subtree;
+            }
+        }
+
+        Some(node)
+    }
+
+    /// Looks up a subdir, returning its subtree
+    pub fn lookup_subdir<'a, P: Into<PathRef<'a>>>(&self, path: P) -> Option<&Self> {
+        let mut node = self;
+
+        for component in path.into() {
+            for ch in component.chars() {
+                let next = &node.children[ch as usize];
+                node = next.as_ref()?;
+            }
+
+            let record = &node.record;
+            let (_, subtree) = record.as_ref()?;
+            node = subtree;
+        }
+
+        Some(node)
+    }
+
+    pub fn insert_tail(&mut self, tail: &str, val: T) -> &mut Self {
+        let mut node = self;
+
+        for ch in tail.chars() {
+            let next = &mut node.children[ch as usize];
+            node = next.get_or_insert_with(|| Box::new(Self::default()));
+        }
+
+        node.record
+            .get_or_insert_with(|| (val, Box::new(Self::default())))
+            .1
+            .as_mut()
+    }
+
+    pub fn get<'a, P: Into<PathRef<'a>>>(&self, path: P) -> Option<&T> {
+        let node = self.lookup_node(path)?;
+        node.record.as_ref().map(|v| &v.0)
+    }
+
+    pub fn iter(&self) -> PPTIter<'_, T> {
+        let mut queue = VecDeque::new();
+        queue.push_back((String::new(), self));
+        PPTIter { queue }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::write::fs::PathPrefixTree;
+
+    #[test]
+    fn test_ppt_insert_get() {
+        let mut ppt = PathPrefixTree::default();
+        let tail = ppt.insert_tail("azbxcy", 12345);
+
+        // Tail is a new PPT
+        assert!(tail.record.is_none());
+        assert!(!tail.children.iter().any(|child| child.is_some()));
+
+        assert_eq!(ppt.get("azbxcy"), Some(&12345));
+    }
+
+    #[test]
+    fn test_ppt_lookup_tail() {
+        let mut ppt = PathPrefixTree::default();
+
+        ppt.insert_tail("foo", 12345).insert_tail("bar", 67890);
+
+        let (val, subtree) = ppt
+            .lookup_node("foo")
+            .expect("Node 'foo' should have been inserted")
+            .record
+            .as_ref()
+            .expect("Node 'foo' should have a record");
+        assert_eq!(*val, 12345);
+        assert_eq!(subtree.get("bar"), Some(&67890));
+    }
+
+    #[test]
+    fn test_ppt_lookup_node() {
+        let mut ppt = PathPrefixTree::default();
+
+        ppt.insert_tail("foo", 12345).insert_tail("bar", 67890);
+
+        let (val, subtree) = ppt
+            .lookup_node("foo/bar")
+            .expect("Node 'foo/bar' should have been inserted")
+            .record
+            .as_ref()
+            .expect("Node 'foo/bar' should have a record");
+        assert_eq!(*val, 67890);
+        assert!(!subtree.children.iter().any(|child| child.is_some()));
+    }
+
+    #[test]
+    fn test_ppt_lookup_node_no_entry() {
+        let mut ppt = PathPrefixTree::default();
+
+        ppt.insert_tail("foo", 12345).insert_tail("bar", 67890);
+
+        assert!(ppt.lookup_node("foo/baz").is_none());
+    }
+
+    #[test]
+    fn test_ppt_lookup_node_no_subtree() {
+        let mut ppt = PathPrefixTree::default();
+
+        ppt.insert_tail("foo", 12345);
+
+        // First component has `fo` instead of `foo`,
+        // so there is no subtree.
+        assert!(ppt.lookup_node("fo/bar").is_none());
+    }
+
+    #[test]
+    fn test_ppt_get_node() {
+        let mut ppt = PathPrefixTree::default();
+
+        ppt.insert_tail("foo", 12345).insert_tail("bar", 67890);
+
+        assert_eq!(ppt.get("foo/bar"), Some(&67890));
+    }
+
+    #[test]
+    fn test_ppt_get_node_no_entry() {
+        let mut ppt = PathPrefixTree::default();
+
+        ppt.insert_tail("foo", 12345).insert_tail("bar", 67890);
+
+        assert_eq!(ppt.get("foo/baz"), None);
+    }
+
+    #[test]
+    fn test_ppt_lookup_subdir() {
+        let mut ppt = PathPrefixTree::default();
+
+        ppt.insert_tail("foo", 1)
+            .insert_tail("bar", 2)
+            .insert_tail("baz", 3);
+
+        let subtree = ppt
+            .lookup_subdir("foo/bar")
+            .expect("Node 'foo/bar' should exist");
+        assert_eq!(subtree.get("baz"), Some(&3));
+    }
+
+    #[test]
+    fn test_ppt_lookup_subdir_no_entry() {
+        let mut ppt = PathPrefixTree::default();
+
+        ppt.insert_tail("foo", 1).insert_tail("bar", 2);
+
+        assert!(ppt.lookup_subdir("foo/baz").is_none());
+    }
+
+    #[test]
+    fn test_ppt_lookup_subdir_no_subtree() {
+        let mut ppt = PathPrefixTree::default();
+
+        ppt.insert_tail("foo", 1).insert_tail("bar", 2);
+
+        // Second component has `ba` instead of `baz`,
+        // so there is no subtree
+        assert!(ppt.lookup_subdir("foo/ba/baz").is_none());
+    }
+
+    #[test]
+    fn test_ppt_substring_path() {
+        let mut ppt = PathPrefixTree::default();
+
+        ppt.insert_tail("abcdef", 12345);
+        ppt.insert_tail("abc", 67890);
+
+        assert_eq!(ppt.get("abc"), Some(&67890));
+        assert_eq!(ppt.get("abcdef"), Some(&12345));
+    }
+
+    #[test]
+    fn test_ppt_lookup_node_mut_mutate_record() {
+        let mut ppt = PathPrefixTree::default();
+        ppt.insert_tail("abc", 54321).insert_tail("def", 12345);
+
+        let record = &mut ppt
+            .lookup_node_mut("abc/def")
+            .expect("Node 'abc/def' should exist")
+            .record
+            .as_mut()
+            .expect("Node 'abc/def' should have a record");
+        record.0 = 67890;
+
+        assert_eq!(ppt.get("abc/def"), Some(&67890));
+    }
+
+    #[test]
+    fn test_ppt_lookup_node_mut_no_record() {
+        let mut ppt = PathPrefixTree::default();
+        ppt.insert_tail("abc", 54321).insert_tail("def", 12345);
+
+        assert!(ppt.lookup_node_mut("abc/defg").is_none());
+    }
+
+    #[test]
+    fn test_ppt_lookup_node_mut_no_subtree() {
+        let mut ppt = PathPrefixTree::default();
+        ppt.insert_tail("abc", 54321).insert_tail("def", 12345);
+
+        // Second component has `de` instead of `def`,
+        // so there is no subtree
+        assert!(ppt.lookup_node_mut("abc/de/ghi").is_none());
+    }
+
+    #[test]
+    fn test_ppt_iterator() {
+        use alloc::string::{String, ToString};
+        use alloc::vec::Vec;
+
+        let mut ppt = PathPrefixTree::default();
+        ppt.insert_tail("abc", 1).insert_tail("tail", 2);
+        ppt.insert_tail("hjk", 3).insert_tail("tail", 4);
+        ppt.insert_tail("xyz", 5).insert_tail("tail", 6);
+
+        let values: Vec<(String, i64)> = ppt.iter().map(|(name, val)| (name, *val)).collect();
+
+        assert_eq!(
+            values,
+            [
+                ("abc".to_string(), 1),
+                ("hjk".to_string(), 3),
+                ("xyz".to_string(), 5),
+            ]
+        );
+    }
+}

--- a/xdvdfs-core/src/write/fs/path/pathvec.rs
+++ b/xdvdfs-core/src/write/fs/path/pathvec.rs
@@ -1,0 +1,187 @@
+use alloc::borrow::ToOwned;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::slice::Iter;
+
+use super::PathRef;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PathVec {
+    components: Vec<String>,
+}
+
+pub type PathVecIter<'a> = Iter<'a, String>;
+
+impl<'a> From<PathRef<'a>> for PathVec {
+    fn from(value: PathRef<'a>) -> Self {
+        let components: Vec<String> = value.map(|component| component.to_owned()).collect();
+        Self { components }
+    }
+}
+
+impl<'a> From<&'a PathVec> for PathRef<'a> {
+    fn from(value: &'a PathVec) -> Self {
+        PathRef::new(value.components.iter().map(|x| x.as_ref()))
+    }
+}
+
+impl PathVec {
+    pub fn as_path_buf(&self, prefix: &std::path::Path) -> std::path::PathBuf {
+        let suffix = std::path::PathBuf::from_iter(self.components.iter());
+        prefix.join(suffix)
+    }
+
+    pub fn is_root(&self) -> bool {
+        self.components.is_empty()
+    }
+
+    pub fn iter(&self) -> PathVecIter<'_> {
+        self.components.iter()
+    }
+
+    pub fn from_base(prefix: &Self, suffix: &str) -> Self {
+        let mut path = prefix.clone();
+        path.components.push(suffix.to_owned());
+        path
+    }
+
+    pub fn as_string(&self) -> String {
+        format!("/{}", self.components.join("/"))
+    }
+
+    pub fn base(&self) -> Option<PathVec> {
+        if self.is_root() {
+            None
+        } else {
+            Some(PathVec {
+                components: self.components[0..self.components.len() - 1].to_vec(),
+            })
+        }
+    }
+
+    pub fn suffix(&self, prefix: &Self) -> Self {
+        let mut components = Vec::new();
+        let mut i1 = self.iter();
+        let mut i2 = prefix.iter();
+
+        loop {
+            let c1 = i1.next();
+            let c2 = i2.next();
+
+            if let Some(component) = c1 {
+                if let Some(component2) = c2 {
+                    assert_eq!(component, component2);
+                } else {
+                    components.push(component.clone());
+                }
+            } else {
+                return Self { components };
+            }
+        }
+    }
+}
+
+impl<'a> FromIterator<&'a str> for PathVec {
+    fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
+        let components = iter
+            .into_iter()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_owned())
+            .collect();
+        Self { components }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::PathVec;
+
+    #[test]
+    fn test_pathvec_to_pathref() {
+        use alloc::borrow::ToOwned;
+
+        let path = PathVec::from_base(&PathVec::default(), "hello");
+        let path = PathVec::from_base(&path, "world");
+        let path: super::PathRef<'_> = (&path).into();
+        let components: alloc::vec::Vec<alloc::string::String> =
+            path.map(|component| component.to_owned()).collect();
+
+        assert_eq!(components, &["hello", "world",]);
+    }
+
+    #[test]
+    fn test_pathref_to_pathvec() {
+        let path = "/hello/world";
+        let path: super::PathRef<'_> = path.into();
+        let path: PathVec = path.into();
+        let components: alloc::vec::Vec<alloc::string::String> = path.iter().cloned().collect();
+
+        assert_eq!(components, &["hello", "world",]);
+    }
+
+    #[test]
+    fn test_pathvec_from_iter() {
+        let path = &["hello", "world"];
+        let path = PathVec::from_iter(path.iter().copied());
+        let components: alloc::vec::Vec<alloc::string::String> = path.iter().cloned().collect();
+
+        assert_eq!(components, &["hello", "world",]);
+    }
+
+    #[test]
+    fn test_pathvec_is_root_root_path() {
+        let path = PathVec::default();
+        assert!(path.is_root());
+    }
+
+    #[test]
+    fn test_pathvec_is_root_non_root_path() {
+        let path = PathVec::default();
+        let path = PathVec::from_base(&path, "nonroot");
+        assert!(!path.is_root());
+    }
+
+    #[test]
+    fn test_pathvec_base_root() {
+        assert_eq!(PathVec::default().base(), None);
+    }
+
+    #[test]
+    fn test_pathvec_base_non_root() {
+        let path = PathVec::default();
+        let path = PathVec::from_base(&path, "nonroot");
+
+        assert_eq!(path.base(), Some(PathVec::default()));
+    }
+
+    #[test]
+    fn test_pathvec_to_path_buf() {
+        let path = PathVec::default();
+        let path = PathVec::from_base(&path, "nonroot");
+        let base = std::path::PathBuf::from("test");
+
+        let path = path.as_path_buf(&base);
+        assert_eq!(path, base.join("nonroot"));
+    }
+
+    #[test]
+    fn test_pathvec_suffix() {
+        let root = PathVec::default();
+        let prefix = PathVec::from_base(&root, "foo");
+        let path = PathVec::from_base(&prefix, "bar");
+        let path = PathVec::from_base(&path, "baz");
+
+        let suffix = path.suffix(&prefix);
+        assert_eq!(suffix, PathVec::from_iter(["bar", "baz",].into_iter()));
+    }
+
+    #[test]
+    fn test_pathvec_to_string() {
+        let root = PathVec::default();
+        let path = PathVec::from_base(&root, "hello");
+        let path = PathVec::from_base(&path, "world");
+
+        assert_eq!(path.as_string(), "/hello/world");
+    }
+}


### PR DESCRIPTION
* Moves PathVec and PathPrefixTree to a new path submodule
* Adds new PathRef type for consuming generic paths (e.g. from strings)
* Adds in-memory filesystem implementation

Fixes #134 