### PR TITLE
cli: Add benchmark subcommand

### DIFF
--- a/xdvdfs-cli/src/cmd_bmark.rs
+++ b/xdvdfs-cli/src/cmd_bmark.rs
@@ -1,0 +1,218 @@
+use std::{
+    error::Error,
+    fmt::{Debug, Display},
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+use anyhow::bail;
+use clap::Args;
+use maybe_async::maybe_async;
+use xdvdfs::{
+    blockdev::NullBlockDevice,
+    write::{
+        self,
+        fs::{FilesystemCopier, FilesystemHierarchy},
+        img::ProgressInfo,
+    },
+};
+
+#[derive(Clone, Default, clap::ValueEnum)]
+enum BlockDeviceType {
+    #[default]
+    Null,
+    Memory,
+}
+
+impl std::fmt::Display for BlockDeviceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Null => f.write_str("null"),
+            Self::Memory => f.write_str("memory"),
+        }
+    }
+}
+
+#[derive(Args)]
+#[command(about = "Benchmark", hide = true)]
+pub struct BmarkArgs {
+    #[arg(help = "Path to source directory or ISO image")]
+    source_path: String,
+
+    #[arg(
+        help = "Number of iterations",
+        default_value_t = 5,
+        short = 'i',
+        required = false
+    )]
+    iterations: usize,
+
+    #[arg(
+        help = "Block device type to pack into",
+        default_value_t = BlockDeviceType::default(),
+        short = 'b',
+    )]
+    blockdev: BlockDeviceType,
+}
+
+#[derive(Clone, Debug)]
+struct BenchmarkMeasurement {
+    file_count: usize,
+    dir_count: usize,
+
+    start_time: Instant,
+    last_msg_time: Duration,
+    forward_pass_end: Duration,
+    backward_pass_end: Duration,
+}
+
+impl Default for BenchmarkMeasurement {
+    fn default() -> Self {
+        Self {
+            file_count: 0,
+            dir_count: 0,
+            start_time: Instant::now(),
+            last_msg_time: Duration::default(),
+            forward_pass_end: Duration::default(),
+            backward_pass_end: Duration::default(),
+        }
+    }
+}
+
+impl Display for BenchmarkMeasurement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "[ {} files, {} directories, forward pass: {:?}, backward pass: {:?} ]",
+            self.file_count,
+            self.dir_count,
+            self.forward_pass_end,
+            self.backward_pass_end.saturating_sub(self.forward_pass_end),
+        )
+    }
+}
+
+impl BenchmarkMeasurement {
+    fn get_progress_callback(&mut self) -> impl FnMut(ProgressInfo) + '_ {
+        self.start_time = Instant::now();
+        |pi| {
+            let msg_time = self.start_time.elapsed();
+            match pi {
+                ProgressInfo::FileCount(count) => {
+                    self.file_count += count;
+                }
+                ProgressInfo::DirCount(count) => {
+                    self.dir_count += count;
+                    self.forward_pass_end = msg_time;
+                }
+                ProgressInfo::FinishedCopyingImageData => self.backward_pass_end = msg_time,
+                _ => {}
+            }
+
+            self.last_msg_time = msg_time;
+        }
+    }
+}
+
+#[maybe_async]
+async fn run_sector_linear_pack_iteration<
+    E1: Error + Debug + Display + Send + Sync + 'static,
+    FS: FilesystemHierarchy<Error = E1> + FilesystemCopier<[u8]>,
+>(
+    fs: &mut FS,
+    iterations: usize,
+) -> anyhow::Result<Vec<BenchmarkMeasurement>> {
+    let mut output = vec![BenchmarkMeasurement::default(); iterations];
+    let mut slbfs = write::fs::SectorLinearBlockFilesystem::new(fs);
+
+    for (idx, bmm) in output.iter_mut().enumerate() {
+        let mut slbd = write::fs::SectorLinearBlockDevice::default();
+
+        let progress_cb = bmm.get_progress_callback();
+        let result = write::img::create_xdvdfs_image(&mut slbfs, &mut slbd, progress_cb).await;
+
+        if let Err(e) = result {
+            eprintln!("Error in iteration {idx}: {e:?}");
+        }
+
+        slbfs.clear_cache().await?;
+    }
+
+    Ok(output)
+}
+
+#[maybe_async]
+async fn run_null_backend_pack_iteration<
+    E1: Error + Debug + Display + Send + Sync + 'static,
+    E2: Error + Debug + Display + Send + Sync + 'static,
+    FS: FilesystemHierarchy<Error = E1> + FilesystemCopier<NullBlockDevice, Error = E2>,
+>(
+    fs: &mut FS,
+    iterations: usize,
+) -> anyhow::Result<Vec<BenchmarkMeasurement>> {
+    let mut output = vec![BenchmarkMeasurement::default(); iterations];
+
+    for (idx, bmm) in output.iter_mut().enumerate() {
+        let mut nullbd = NullBlockDevice::default();
+        let progress_cb = bmm.get_progress_callback();
+
+        let result = write::img::create_xdvdfs_image(fs, &mut nullbd, progress_cb).await;
+        if let Err(e) = result {
+            eprintln!("Error in iteration {idx}: {e:?}");
+        }
+
+        fs.clear_cache().await?;
+    }
+
+    Ok(output)
+}
+
+#[maybe_async]
+pub async fn cmd_bmark(args: &BmarkArgs) -> anyhow::Result<()> {
+    let source_path = PathBuf::from(&args.source_path);
+
+    let meta = std::fs::metadata(&source_path)?;
+    let is_dir = meta.is_dir();
+
+    let result = if is_dir {
+        let mut fs = write::fs::StdFilesystem::create(&source_path);
+
+        match args.blockdev {
+            BlockDeviceType::Null => {
+                run_null_backend_pack_iteration(&mut fs, args.iterations).await
+            }
+            BlockDeviceType::Memory => {
+                run_sector_linear_pack_iteration(&mut fs, args.iterations).await
+            }
+        }
+    } else if meta.is_file() {
+        let source = crate::img::open_image_raw(&source_path).await?;
+
+        match args.blockdev {
+            BlockDeviceType::Null => {
+                let mut fs =
+                    write::fs::XDVDFSFilesystem::<_, _, write::fs::NullCopier<_>>::new(source)
+                        .await
+                        .ok_or(anyhow::anyhow!("Failed to create XDVDFS filesystem"))?;
+                run_null_backend_pack_iteration(&mut fs, args.iterations).await
+            }
+            BlockDeviceType::Memory => {
+                let mut fs =
+                    write::fs::XDVDFSFilesystem::<_, _, write::fs::DefaultCopier<_, _>>::new(
+                        source,
+                    )
+                    .await
+                    .ok_or(anyhow::anyhow!("Failed to create XDVDFS filesystem"))?;
+                run_sector_linear_pack_iteration(&mut fs, args.iterations).await
+            }
+        }
+    } else {
+        bail!("Symlink image sources are not supported");
+    };
+
+    for (iter, result) in result?.into_iter().enumerate() {
+        println!("Iteration {iter}: {result}");
+    }
+
+    Ok(())
+}

--- a/xdvdfs-cli/src/main.rs
+++ b/xdvdfs-cli/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use maybe_async::maybe_async;
 
+mod cmd_bmark;
 mod cmd_build_image;
 mod cmd_compress;
 mod cmd_info;
@@ -50,6 +51,7 @@ enum Cmd {
     BuildImage(cmd_build_image::BuildImageArgs),
     ImageSpec(cmd_build_image::ImageSpecArgs),
     Compress(cmd_compress::CompressArgs),
+    Bmark(cmd_bmark::BmarkArgs),
 
     #[command(hide = true)]
     ExtractXiso(exiso_compat::EXCommand),
@@ -70,6 +72,7 @@ async fn run_command(cmd: &Cmd) -> Result<(), anyhow::Error> {
         BuildImage(args) => cmd_build_image::cmd_build_image(args).await,
         ImageSpec(args) => cmd_build_image::cmd_image_spec(args).await,
         Compress(args) => cmd_compress::cmd_compress(args).await,
+        Bmark(args) => cmd_bmark::cmd_bmark(args).await,
         ExtractXiso(_) => unreachable!("should be handled before entering async context"),
     }
 }

--- a/xdvdfs-core/src/blockdev.rs
+++ b/xdvdfs-core/src/blockdev.rs
@@ -63,6 +63,40 @@ pub trait BlockDeviceWrite: Send + Sync {
     }
 }
 
+/// Block device that eats all write operations, without performing any writes.
+/// Used for benchmarking. len() will return the correct value based on any write
+/// ops given to the device, but the writes are not persisted and operations return
+/// immediately, without yielding.
+#[derive(Default, Copy, Clone)]
+pub struct NullBlockDevice {
+    size: u64,
+}
+
+impl NullBlockDevice {
+    pub fn write_size_adjustment(&mut self, offset: u64, size: u64) {
+        self.size = core::cmp::max(self.size, offset + size);
+    }
+}
+
+#[cfg(feature = "write")]
+#[maybe_async]
+impl BlockDeviceWrite for NullBlockDevice {
+    type WriteError = core::convert::Infallible;
+
+    async fn write(&mut self, offset: u64, buffer: &[u8]) -> Result<(), Self::WriteError> {
+        self.write_size_adjustment(offset, buffer.len() as u64);
+        Ok(())
+    }
+
+    async fn len(&mut self) -> Result<u64, Self::WriteError> {
+        Ok(self.size)
+    }
+
+    async fn is_empty(&mut self) -> Result<bool, Self::WriteError> {
+        Ok(self.size == 0)
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub struct OutOfBounds;
 

--- a/xdvdfs-core/src/write/fs/copier.rs
+++ b/xdvdfs-core/src/write/fs/copier.rs
@@ -1,0 +1,66 @@
+use alloc::boxed::Box;
+use maybe_async::maybe_async;
+
+use super::PathVec;
+use crate::blockdev::BlockDeviceWrite;
+
+/// A trait for copying data out of a filesystem.
+///
+/// Allows for copying data from a specified filesystem path
+/// into an output block device, specialized by the block device type.
+/// Multiple implementations of this trait allow the filesystem to be
+/// used to create images on various output types.
+#[maybe_async]
+pub trait FilesystemCopier<BDW: BlockDeviceWrite + ?Sized>: Send + Sync {
+    type Error;
+
+    /// Copy the entire contents of file `src` into `dest` at the specified offset
+    async fn copy_file_in(
+        &mut self,
+        src: &PathVec,
+        dest: &mut BDW,
+        input_offset: u64,
+        output_offset: u64,
+        size: u64,
+    ) -> Result<u64, Self::Error>;
+}
+
+#[maybe_async]
+impl<E, BDW: BlockDeviceWrite> FilesystemCopier<BDW> for Box<dyn FilesystemCopier<BDW, Error = E>> {
+    type Error = E;
+
+    async fn copy_file_in(
+        &mut self,
+        src: &PathVec,
+        dest: &mut BDW,
+        input_offset: u64,
+        output_offset: u64,
+        size: u64,
+    ) -> Result<u64, E> {
+        self.as_mut()
+            .copy_file_in(src, dest, input_offset, output_offset, size)
+            .await
+    }
+}
+
+#[maybe_async]
+impl<E, BDW, F> FilesystemCopier<BDW> for &mut F
+where
+    BDW: BlockDeviceWrite + ?Sized,
+    F: FilesystemCopier<BDW, Error = E> + ?Sized,
+{
+    type Error = E;
+
+    async fn copy_file_in(
+        &mut self,
+        src: &PathVec,
+        dest: &mut BDW,
+        input_offset: u64,
+        output_offset: u64,
+        size: u64,
+    ) -> Result<u64, E> {
+        (**self)
+            .copy_file_in(src, dest, input_offset, output_offset, size)
+            .await
+    }
+}

--- a/xdvdfs-core/src/write/fs/hierarchy.rs
+++ b/xdvdfs-core/src/write/fs/hierarchy.rs
@@ -1,0 +1,121 @@
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use maybe_async::maybe_async;
+
+use super::PathVec;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FileType {
+    File,
+    Directory,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FileEntry {
+    pub name: String,
+    pub file_type: FileType,
+    pub len: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct DirectoryTreeEntry {
+    pub dir: PathVec,
+    pub listing: Vec<FileEntry>,
+}
+
+/// Returns a recursive listing of paths in order
+/// e.g. for a path hierarchy like this:
+/// /
+/// -- /a
+/// -- -- /a/b
+/// -- /b
+/// It might return the list: ["/", "/a", "/a/b", "/b"]
+/// `directory_found_callback` should be called each time
+/// a new directory is found, with the number of entries
+/// in that directory (for progress tracking).
+#[maybe_async]
+pub async fn dir_tree<FS: FilesystemHierarchy + ?Sized>(
+    fs: &mut FS,
+    directory_found_callback: &mut impl FnMut(usize),
+) -> Result<Vec<DirectoryTreeEntry>, FS::Error> {
+    let mut dirs = alloc::vec![PathVec::default()];
+    let mut out = Vec::new();
+
+    while let Some(dir) = dirs.pop() {
+        let listing = fs.read_dir(&dir).await?;
+        directory_found_callback(listing.len());
+
+        for entry in listing.iter() {
+            if let FileType::Directory = entry.file_type {
+                dirs.push(PathVec::from_base(&dir, &entry.name));
+            }
+        }
+
+        out.push(DirectoryTreeEntry { dir, listing });
+    }
+
+    Ok(out)
+}
+
+/// A trait for filesystem hierarchies, representing any filesystem
+/// structure with hierarchical directories.
+///
+/// This trait allows for scanning a given directory within a filesystem
+/// for a list of its entries and entry metadata.
+#[maybe_async]
+pub trait FilesystemHierarchy: Send + Sync {
+    type Error;
+
+    /// Read a directory, and return a list of entries within it
+    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, Self::Error>;
+
+    /// Clear any cached data built during operation
+    /// After clearing the cache, function should behave as though the object
+    /// has just been initialized.
+    async fn clear_cache(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Display a filesystem path as a String
+    fn path_to_string(&self, path: &PathVec) -> String {
+        path.as_string()
+    }
+}
+
+#[maybe_async]
+impl<E> FilesystemHierarchy for Box<dyn FilesystemHierarchy<Error = E>> {
+    type Error = E;
+
+    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, E> {
+        self.as_mut().read_dir(path).await
+    }
+
+    async fn clear_cache(&mut self) -> Result<(), Self::Error> {
+        self.as_mut().clear_cache().await
+    }
+
+    fn path_to_string(&self, path: &PathVec) -> String {
+        self.as_ref().path_to_string(path)
+    }
+}
+
+#[maybe_async]
+impl<E, F> FilesystemHierarchy for &mut F
+where
+    F: FilesystemHierarchy<Error = E> + ?Sized,
+{
+    type Error = E;
+
+    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, E> {
+        (**self).read_dir(path).await
+    }
+
+    async fn clear_cache(&mut self) -> Result<(), Self::Error> {
+        (**self).clear_cache().await
+    }
+
+    fn path_to_string(&self, path: &PathVec) -> String {
+        (**self).path_to_string(path)
+    }
+}

--- a/xdvdfs-core/src/write/fs/mod.rs
+++ b/xdvdfs-core/src/write/fs/mod.rs
@@ -1,20 +1,17 @@
-use alloc::boxed::Box;
-use alloc::string::String;
-use alloc::vec::Vec;
+pub mod path;
+pub use path::*;
 
-use core::fmt::Debug;
+// Filesystem traits
+mod copier;
+mod hierarchy;
+pub use copier::*;
+pub use hierarchy::*;
 
-use crate::blockdev::BlockDeviceWrite;
-
-use maybe_async::maybe_async;
-
+// Filesystem implementations
 mod memory;
 mod remap;
 mod sector_linear;
 mod xdvdfs;
-
-pub mod path;
-pub use path::*;
 
 pub use memory::*;
 pub use remap::*;
@@ -26,130 +23,3 @@ mod stdfs;
 
 #[cfg(not(target_family = "wasm"))]
 pub use stdfs::*;
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum FileType {
-    File,
-    Directory,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct FileEntry {
-    pub name: String,
-    pub file_type: FileType,
-    pub len: u64,
-}
-
-#[derive(Clone, Debug)]
-pub struct DirectoryTreeEntry {
-    pub dir: PathVec,
-    pub listing: Vec<FileEntry>,
-}
-
-/// A trait for filesystem hierarchies, representing any filesystem
-/// structure with hierarchical directories.
-///
-/// This trait allows for scanning a given directory within a filesystem
-/// for a list of its entries and entry metadata.
-#[maybe_async]
-pub trait FilesystemHierarchy: Send + Sync {
-    type Error;
-
-    /// Read a directory, and return a list of entries within it
-    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, Self::Error>;
-
-    /// Display a filesystem path as a String
-    fn path_to_string(&self, path: &PathVec) -> String {
-        path.as_string()
-    }
-}
-
-#[maybe_async]
-impl<E> FilesystemHierarchy for Box<dyn FilesystemHierarchy<Error = E>> {
-    type Error = E;
-
-    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, E> {
-        self.as_mut().read_dir(path).await
-    }
-
-    fn path_to_string(&self, path: &PathVec) -> String {
-        self.as_ref().path_to_string(path)
-    }
-}
-
-#[maybe_async]
-impl<E, F> FilesystemHierarchy for &mut F
-where
-    F: FilesystemHierarchy<Error = E> + ?Sized,
-{
-    type Error = E;
-
-    async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, E> {
-        (**self).read_dir(path).await
-    }
-
-    fn path_to_string(&self, path: &PathVec) -> String {
-        (**self).path_to_string(path)
-    }
-}
-
-/// A trait for copying data out of a filesystem.
-///
-/// Allows for copying data from a specified filesystem path
-/// into an output block device, specialized by the block device type.
-/// Multiple implementations of this trait allow the filesystem to be
-/// used to create images on various output types.
-#[maybe_async]
-pub trait FilesystemCopier<BDW: BlockDeviceWrite + ?Sized>: Send + Sync {
-    type Error;
-
-    /// Copy the entire contents of file `src` into `dest` at the specified offset
-    async fn copy_file_in(
-        &mut self,
-        src: &PathVec,
-        dest: &mut BDW,
-        input_offset: u64,
-        output_offset: u64,
-        size: u64,
-    ) -> Result<u64, Self::Error>;
-}
-
-#[maybe_async]
-impl<E, BDW: BlockDeviceWrite> FilesystemCopier<BDW> for Box<dyn FilesystemCopier<BDW, Error = E>> {
-    type Error = E;
-
-    async fn copy_file_in(
-        &mut self,
-        src: &PathVec,
-        dest: &mut BDW,
-        input_offset: u64,
-        output_offset: u64,
-        size: u64,
-    ) -> Result<u64, E> {
-        self.as_mut()
-            .copy_file_in(src, dest, input_offset, output_offset, size)
-            .await
-    }
-}
-
-#[maybe_async]
-impl<E, BDW, F> FilesystemCopier<BDW> for &mut F
-where
-    BDW: BlockDeviceWrite + ?Sized,
-    F: FilesystemCopier<BDW, Error = E> + ?Sized,
-{
-    type Error = E;
-
-    async fn copy_file_in(
-        &mut self,
-        src: &PathVec,
-        dest: &mut BDW,
-        input_offset: u64,
-        output_offset: u64,
-        size: u64,
-    ) -> Result<u64, E> {
-        (**self)
-            .copy_file_in(src, dest, input_offset, output_offset, size)
-            .await
-    }
-}

--- a/xdvdfs-core/src/write/fs/remap.rs
+++ b/xdvdfs-core/src/write/fs/remap.rs
@@ -336,6 +336,11 @@ where
 
         Ok(entries)
     }
+
+    async fn clear_cache(&mut self) -> Result<(), Self::Error> {
+        // TODO: Clear underlying FS cache and regenerate
+        unimplemented!("cache clearing on a remap filesystem is not implemented")
+    }
 }
 
 #[maybe_async]

--- a/xdvdfs-core/src/write/fs/sector_linear/block_filesystem.rs
+++ b/xdvdfs-core/src/write/fs/sector_linear/block_filesystem.rs
@@ -34,6 +34,14 @@ where
     async fn read_dir(&mut self, path: &PathVec) -> Result<Vec<FileEntry>, Self::Error> {
         self.fs.read_dir(path).await
     }
+
+    async fn clear_cache(&mut self) -> Result<(), Self::Error> {
+        self.fs.clear_cache().await
+    }
+
+    fn path_to_string(&self, path: &PathVec) -> alloc::string::String {
+        self.fs.path_to_string(path)
+    }
 }
 
 #[maybe_async]

--- a/xdvdfs-core/src/write/img.rs
+++ b/xdvdfs-core/src/write/img.rs
@@ -21,6 +21,7 @@ pub enum ProgressInfo {
     DirCount(usize),
     DirAdded(String, u64),
     FileAdded(String, u64),
+    FinishedCopyingImageData,
     FinishedPacking,
 }
 
@@ -181,6 +182,8 @@ pub async fn create_xdvdfs_image<
             }
         }
     }
+
+    progress_callback(ProgressInfo::FinishedCopyingImageData);
 
     // Write volume info to sector 32
     // FIXME: Set timestamp


### PR DESCRIPTION
Adds a `bmark` subcommand for benchmarking the xdvdfs image creation loops on real images. For each iteration, the time spent in the forward and backward passes are measured and reported.

Currently only stdfs and xdvdfs sources are supported as input. In the future, memoryfs and remapfs sources may be interesting, to remove bias and to benchmark the remap implementation.

A null blockdevice is added that does not perform any write operations, eliminating overhead from file copy operations. This enables the measurement of filesystem read operations and the packing algorithm itself, which otherwise spends most of its runtime copying files.

The sector linear block device is also supported as an output, which measures the overhead of copying directory tables into the image. The copying of files is ideally negligible, but the implementation here seems inefficient.