### PR TITLE
fsd: Fix out of bounds read error in pack overlay filesystem

### DIFF
--- a/xdvdfs-fsd/src/fsproto/mod.rs
+++ b/xdvdfs-fsd/src/fsproto/mod.rs
@@ -32,6 +32,13 @@ impl FilesystemErrorKind {
             source: Some(Box::from(source)),
         }
     }
+
+    pub fn with_str(self, source: &'static str) -> FilesystemError {
+        FilesystemError {
+            kind: self,
+            source: Some(source.into()),
+        }
+    }
 }
 
 impl From<FilesystemErrorKind> for FilesystemError {

--- a/xdvdfs-fsd/src/overlay_fs/packfs.rs
+++ b/xdvdfs-fsd/src/overlay_fs/packfs.rs
@@ -198,7 +198,7 @@ where
         // Since we might have given a fake size in getattr,
         // ensure any out of bounds reads are rejected or clamped
         if offset >= image_size && size != 0 {
-            return Err(FilesystemErrorKind::IOError.into());
+            return Ok((Vec::new(), true));
         }
 
         if offset + size > image_size {


### PR DESCRIPTION
When reading out of bounds in the pack overlay filesystem, return EOF instead of an error.