### PR TITLE
core: Replace Box/mut ref impls with Deref impls for traits

### DIFF
--- a/xdvdfs-core/src/blockdev/byte_slice.rs
+++ b/xdvdfs-core/src/blockdev/byte_slice.rs
@@ -1,9 +1,10 @@
-use core::fmt::Display;
-
+#[cfg(not(feature = "sync"))]
 use alloc::boxed::Box;
+
 use maybe_async::maybe_async;
 
 use core::error::Error;
+use core::fmt::Display;
 
 use super::{BlockDeviceRead, BlockDeviceWrite};
 
@@ -38,27 +39,6 @@ impl BlockDeviceRead for [u8] {
 
 #[maybe_async]
 impl BlockDeviceWrite for [u8] {
-    type WriteError = OutOfBounds;
-
-    async fn write(&mut self, offset: u64, buffer: &[u8]) -> Result<(), Self::WriteError> {
-        let offset: usize = offset.try_into().map_err(|_| OutOfBounds)?;
-        let buffer_size = <[u8]>::len(self);
-        if offset >= buffer_size || buffer_size - offset < buffer.len() {
-            return Err(OutOfBounds);
-        }
-
-        self[offset..(offset + buffer.len())].copy_from_slice(buffer);
-        Ok(())
-    }
-
-    async fn len(&mut self) -> Result<u64, Self::WriteError> {
-        Ok(<[u8]>::len(self) as u64)
-    }
-}
-
-// TODO: Remove this impl, it is covered by [u8] via as_mut_slice()
-#[maybe_async]
-impl BlockDeviceWrite for Box<[u8]> {
     type WriteError = OutOfBounds;
 
     async fn write(&mut self, offset: u64, buffer: &[u8]) -> Result<(), Self::WriteError> {

--- a/xdvdfs-core/src/checksum.rs
+++ b/xdvdfs-core/src/checksum.rs
@@ -9,7 +9,7 @@ use crate::{
 use maybe_async::maybe_async;
 
 #[maybe_async]
-pub async fn checksum<BDR: BlockDeviceRead>(
+pub async fn checksum<BDR: BlockDeviceRead + ?Sized>(
     dev: &mut BDR,
     volume: &VolumeDescriptor,
 ) -> Result<[u8; 32], util::Error<BDR::ReadError>> {

--- a/xdvdfs-core/src/layout/disk_data.rs
+++ b/xdvdfs-core/src/layout/disk_data.rs
@@ -106,18 +106,8 @@ mod test {
 #[cfg(all(test, feature = "std"))]
 mod test_std {
     use crate::layout::{DirectoryEntryDiskData, DirentAttributes, DiskRegion};
-
-    struct MockSeeker(i64);
-    impl std::io::Seek for MockSeeker {
-        fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
-            match pos {
-                std::io::SeekFrom::End(_) => unimplemented!(),
-                std::io::SeekFrom::Start(s) => self.0 = s as i64,
-                std::io::SeekFrom::Current(c) => self.0 += c,
-            }
-            Ok(self.0 as u64)
-        }
-    }
+    use alloc::vec::Vec;
+    use std::io::Cursor;
 
     #[test]
     fn test_layout_dirent_disk_data_seek_to() {
@@ -127,7 +117,7 @@ mod test_std {
             filename_length: 0,
         };
 
-        let mut seeker = MockSeeker(0);
+        let mut seeker = Cursor::new(Vec::new());
         let result = dirent.seek_to(&mut seeker).expect("Seek should succeed");
         assert_eq!(result, 2048);
     }

--- a/xdvdfs-core/src/write/fs/stdfs.rs
+++ b/xdvdfs-core/src/write/fs/stdfs.rs
@@ -101,35 +101,6 @@ where
 }
 
 #[maybe_async]
-impl FilesystemCopier<alloc::boxed::Box<[u8]>> for StdFilesystem {
-    type Error = std::io::Error;
-
-    async fn copy_file_in(
-        &mut self,
-        src: PathRef<'_>,
-        dest: &mut alloc::boxed::Box<[u8]>,
-        input_offset: u64,
-        output_offset: u64,
-        size: u64,
-    ) -> Result<u64, std::io::Error> {
-        use std::io::{Read, Seek, SeekFrom};
-
-        let src = src.as_path_buf(&self.root);
-        let file = std::fs::File::open(src)?;
-        let mut file = std::io::BufReader::with_capacity(1024 * 1024, file);
-        file.seek(SeekFrom::Start(input_offset))?;
-
-        let output_offset = output_offset as usize;
-        let size = core::cmp::min(size as usize, <[u8]>::len(dest) - output_offset);
-
-        let dest = &mut dest[output_offset..(output_offset + size)];
-        let bytes_read = Read::read(&mut file, dest)?;
-        dest[(output_offset + bytes_read)..].fill(0);
-        Ok(<[u8]>::len(dest) as u64)
-    }
-}
-
-#[maybe_async]
 impl FilesystemCopier<[u8]> for StdFilesystem {
     type Error = std::io::Error;
 


### PR DESCRIPTION
* Filesystem traits have their Box and mut ref impls replaced with Deref, which should be functionally identical but no longer duplicates code
* Block devices lose their Box impls, but gain a blanket io::Write impl. There aren't any structures that store a BlockDeviceWrite, so the Box impl is not as useful as the blanket io::Write impl.