### PR TITLE
fsd: Limit number of packed images kept in memory

### DIFF
--- a/xdvdfs-core/src/write/fs/sector_linear/block_device.rs
+++ b/xdvdfs-core/src/write/fs/sector_linear/block_device.rs
@@ -81,6 +81,10 @@ impl SectorLinearBlockDevice {
         self.num_sectors() * (layout::SECTOR_SIZE as u64)
     }
 
+    pub fn clear(&mut self) {
+        self.contents.clear();
+    }
+
     fn get_or_empty(&self, sector: u64) -> Option<(u64, &SectorLinearBlockRegion)> {
         let index = sector;
         self.contents
@@ -176,6 +180,20 @@ mod test {
     use crate::write::fs::{PathVec, SectorLinearBlockRegion};
 
     use super::{SectorLinearBlockDevice, SectorLinearBlockSectorContents};
+
+    #[test]
+    fn test_sector_linear_dev_clear() {
+        let mut slbd = SectorLinearBlockDevice::default();
+        slbd.contents.insert(
+            5,
+            SectorLinearBlockRegion::Fill {
+                byte: 0xff,
+                sectors: 2,
+            },
+        );
+        slbd.clear();
+        assert_eq!(slbd.size(), 0);
+    }
 
     #[test]
     fn test_sector_linear_dev_size_end_fill() {

--- a/xdvdfs-fsd/src/mount.rs
+++ b/xdvdfs-fsd/src/mount.rs
@@ -100,7 +100,7 @@ fn mount_pack_overlay<FSM: FSMounter>(
     let fs = OverlayFSBuilder::new(src)
         .with_provider(crate::img_fs::ImageFilesystemProvider)
         .with_provider(crate::overlay_fs::truncatefs::ImageTruncateFSFileProvider)
-        .with_provider(crate::overlay_fs::packfs::PackOverlayProvider)
+        .with_provider(crate::overlay_fs::packfs::PackOverlayProvider::default())
         .build()?;
 
     if let Some(dm) = dm {


### PR DESCRIPTION
Ensure overall memory usage cannot run away if many images are read from before the daemon is restarted. This does not put any hard cap on the memory usage but reduces usage in cases where many images are accessed subsequently.